### PR TITLE
use clisops, skip gunicorn

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,31 +13,13 @@ dependencies:
 # tests
 - pytest
 # daops
-# - xarray>=0.15
-# - dask
-# - netcdf4
-# clisops
-# clisops
-- numpy>=1.16
 - xarray>=0.15
-- pandas>=1.0.3
-- cftime>=1.0.4
-- netCDF4>=1.4
-- poppler>=0.67
-- fiona>=1.8
-- geojson>=2.5.0
-- shapely>=1.6
-- geopandas>=0.7
-- dask>=2.6.0
-- bottleneck>=1.3.1,<1.4
-- pyproj>=2.5
+- dask
+- netcdf4
+- clisops>=0.2.0,<0.3
 # workflow
 - networkx
 # tests
 - pytest
-# wps deployment
-- gunicorn
-- psycopg2
 - pip:
-  - clisops>=0.2.0<0.3
   - daops>=0.2.0<0.3


### PR DESCRIPTION
## Overview

This PR adds the clisops conda package to the environment. It removes the unnecessary gunicorn package.

## Related Issue / Discussion

## Additional Information

