### PR TITLE
use conftest to set roocs config

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,11 +1,3 @@
 # -*- coding: utf-8 -*-
 
 """Unit test package for rook."""
-import os
-
-from .common import ROOCS_CFG, write_roocs_cfg
-
-# create roocs config for testing
-write_roocs_cfg()
-# point to roocs cfg in environment
-os.environ['ROOCS_CONFIG'] = ROOCS_CFG

--- a/tests/common.py
+++ b/tests/common.py
@@ -39,6 +39,8 @@ def write_roocs_cfg():
     cfg = Template(cfg_templ).render(base_dir=TESTS_HOME)
     with open(ROOCS_CFG, 'w') as fp:
         fp.write(cfg)
+    # point to roocs cfg in environment
+    os.environ['ROOCS_CONFIG'] = ROOCS_CFG
 
 
 def resource_file(filepath):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+from tests.common import write_roocs_cfg
+
+write_roocs_cfg()


### PR DESCRIPTION
## Overview

This PR adds `tests/conftest.py` with the init of the `roocs.ini` config file.

## Related Issue / Discussion

PR https://github.com/roocs/dachar/pull/82

## Additional Information

