### PR TITLE
skip defaults in wps subset process

### DIFF
--- a/rook/processes/wps_subset.py
+++ b/rook/processes/wps_subset.py
@@ -17,7 +17,7 @@ class Subset(Process):
             LiteralInput('time', 'Time Period',
                          abstract='Example: 2085-01-01/2120-12-30',
                          data_type='string',
-                         min_occurs=1,
+                         min_occurs=0,
                          max_occurs=1,),
             LiteralInput('area', 'Area',
                          abstract="Example: 0.,49.,10.,65",
@@ -74,8 +74,9 @@ class Subset(Process):
 
         subset_args = {
             'collection': collection,
-            'time': request.inputs['time'][0].data
         }
+        if 'time' in request.inputs:
+            subset_args['time'] = request.inputs['time'][0].data
         if 'level' in request.inputs:
             subset_args['level'] = request.inputs['level'][0].data
         if 'area' in request.inputs:

--- a/rook/processes/wps_subset.py
+++ b/rook/processes/wps_subset.py
@@ -10,8 +10,8 @@ class Subset(Process):
     def __init__(self):
         inputs = [
             LiteralInput('collection', 'Collection',
+                         abstract='cmip5.output1.MOHC.HadGEM2-ES.rcp85.mon.atmos.Amon.r1i1p1.latest.tas',
                          data_type='string',
-                         default='cmip5.output1.MOHC.HadGEM2-ES.rcp85.mon.atmos.Amon.r1i1p1.latest.tas',
                          min_occurs=1,
                          max_occurs=10,),
             LiteralInput('time', 'Time Period',

--- a/rook/processes/wps_subset.py
+++ b/rook/processes/wps_subset.py
@@ -13,7 +13,7 @@ class Subset(Process):
                          abstract='cmip5.output1.MOHC.HadGEM2-ES.rcp85.mon.atmos.Amon.r1i1p1.latest.tas',
                          data_type='string',
                          min_occurs=1,
-                         max_occurs=10,),
+                         max_occurs=1,),
             LiteralInput('time', 'Time Period',
                          abstract='Example: 2085-01-01/2120-12-30',
                          data_type='string',

--- a/rook/processes/wps_subset.py
+++ b/rook/processes/wps_subset.py
@@ -15,20 +15,20 @@ class Subset(Process):
                          min_occurs=1,
                          max_occurs=10,),
             LiteralInput('time', 'Time Period',
+                         abstract='Example: 2085-01-01/2120-12-30',
                          data_type='string',
-                         default="2085-01-01/2120-12-30",
                          min_occurs=1,
                          max_occurs=1,),
             LiteralInput('area', 'Area',
+                         abstract="Example: 0.,49.,10.,65",
                          data_type='string',
-                         default='0.,49.,10.,65',
                          min_occurs=0,
                          max_occurs=1,),
             LiteralInput('level', 'Level',
+                         abstract="Example: 0/1000",
                          data_type='string',
-                         default='0/1000',
                          min_occurs=0,
-                         max_occurs=10,),
+                         max_occurs=1,),
             LiteralInput('pre_checked', 'Pre-Checked', data_type='boolean',
                          abstract='Use checked data only.',
                          default='0',
@@ -72,10 +72,15 @@ class Subset(Process):
             # 'filenamer': dconfig.filenamer,
         }
 
-        kwargs = parameterise.parameterise(collection=collection,
-                                           time=request.inputs['time'][0].data,
-                                           level=request.inputs['level'][0].data,
-                                           area=request.inputs['area'][0].data)
+        subset_args = {
+            'collection': collection,
+            'time': request.inputs['time'][0].data
+        }
+        if 'level' in request.inputs:
+            subset_args['level'] = request.inputs['level'][0].data
+        if 'area' in request.inputs:
+            subset_args['area'] = request.inputs['area'][0].data
+        kwargs = parameterise.parameterise(**subset_args)
         kwargs.update(config_args)
         result = subset(**kwargs)
         response.outputs['output'].file = result.file_paths[0]

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ replace = "version": "{new_version}",
 addopts =
 	--strict
 	--tb=native
-	tests/
+	
 python_files = test_*.py
 markers =
 	online: mark test to need internet connection

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ replace = "version": "{new_version}",
 addopts =
 	--strict
 	--tb=native
-	
+	tests/
 python_files = test_*.py
 markers =
 	online: mark test to need internet connection

--- a/tests/test_wps_subset.py
+++ b/tests/test_wps_subset.py
@@ -9,7 +9,7 @@ from .common import get_output, PYWPS_CFG
 from rook.processes.wps_subset import Subset
 
 
-def test_wps_subset():
+def test_wps_subset_with_time():
     client = client_for(Service(processes=[Subset()], cfgfiles=[PYWPS_CFG]))
     datainputs = "collection=cmip5.output1.MOHC.HadGEM2-ES.rcp85.mon.atmos.Amon.r1i1p1.latest.tas"
     datainputs += ";time=2085-01-01/2120-12-30"
@@ -20,11 +20,11 @@ def test_wps_subset():
     assert 'tas_mon_HadGEM2-ES_rcp85_r1i1p1_20850116-21201216.nc' in get_output(resp.xml)['output']
 
 
-def test_wps_subset_missing_time():
+def test_wps_subset_missing_collection():
     client = client_for(Service(processes=[Subset()], cfgfiles=[PYWPS_CFG]))
-    datainputs = "collection=cmip5.output1.MOHC.HadGEM2-ES.rcp85.mon.atmos.Amon.r1i1p1.latest.tas"
+    # datainputs = "collection=cmip5.output1.MOHC.HadGEM2-ES.rcp85.mon.atmos.Amon.r1i1p1.latest.tas"
+    datainputs = ""
     resp = client.get(
         "?service=WPS&request=Execute&version=1.0.0&identifier=subset&datainputs={}".format(
             datainputs))
-    assert_response_success(resp)
-    assert 'tas_mon_HadGEM2-ES_rcp85_r1i1p1_20051216-22991216.nc' in get_output(resp.xml)['output']
+    assert_process_exception(resp, code='MissingParameterValue')

--- a/tests/test_wps_subset.py
+++ b/tests/test_wps_subset.py
@@ -26,4 +26,5 @@ def test_wps_subset_missing_time():
     resp = client.get(
         "?service=WPS&request=Execute&version=1.0.0&identifier=subset&datainputs={}".format(
             datainputs))
-    assert_process_exception(resp, code='MissingParameterValue')
+    assert_response_success(resp)
+    assert 'tas_mon_HadGEM2-ES_rcp85_r1i1p1_20051216-22991216.nc' in get_output(resp.xml)['output']

--- a/tests/test_wps_subset.py
+++ b/tests/test_wps_subset.py
@@ -1,5 +1,9 @@
 from pywps import Service
-from pywps.tests import client_for, assert_response_success
+from pywps.tests import (
+    client_for,
+    assert_response_success,
+    assert_process_exception
+)
 
 from .common import get_output, PYWPS_CFG
 from rook.processes.wps_subset import Subset
@@ -8,8 +12,18 @@ from rook.processes.wps_subset import Subset
 def test_wps_subset():
     client = client_for(Service(processes=[Subset()], cfgfiles=[PYWPS_CFG]))
     datainputs = "collection=cmip5.output1.MOHC.HadGEM2-ES.rcp85.mon.atmos.Amon.r1i1p1.latest.tas"
+    datainputs += ";time=2085-01-01/2120-12-30"
     resp = client.get(
         "?service=WPS&request=Execute&version=1.0.0&identifier=subset&datainputs={}".format(
             datainputs))
     assert_response_success(resp)
     assert 'tas_mon_HadGEM2-ES_rcp85_r1i1p1_20850116-21201216.nc' in get_output(resp.xml)['output']
+
+
+def test_wps_subset_missing_time():
+    client = client_for(Service(processes=[Subset()], cfgfiles=[PYWPS_CFG]))
+    datainputs = "collection=cmip5.output1.MOHC.HadGEM2-ES.rcp85.mon.atmos.Amon.r1i1p1.latest.tas"
+    resp = client.get(
+        "?service=WPS&request=Execute&version=1.0.0&identifier=subset&datainputs={}".format(
+            datainputs))
+    assert_process_exception(resp, code='MissingParameterValue')


### PR DESCRIPTION
## Overview

This PR removes the default values in wps subset process. The `time` parameter is mandatory.

## Related Issue / Discussion

https://github.com/roocs/34e-mngmt/issues/42

## Additional Information


