### PR TITLE
Use only metalink output

### DIFF
--- a/notebooks/environment.yml
+++ b/notebooks/environment.yml
@@ -10,4 +10,4 @@ dependencies:
   - nodejs
   - birdy
   - pip:
-    - -e git+https://github.com/cehbrecht/pymetalink.git@patched#egg=metalink
+    - -e git+https://github.com/metalink-dev/pymetalink.git@master#egg=metalink

--- a/notebooks/rook-demo.ipynb
+++ b/notebooks/rook-demo.ipynb
@@ -14,8 +14,7 @@
    "outputs": [],
    "source": [
     "from birdy import WPSClient\n",
-    "url = 'http://localhost:5000/wps'\n",
-    "rooki = WPSClient(url)"
+    "rooki = WPSClient('http://localhost:5000/wps')"
    ]
   },
   {
@@ -56,7 +55,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "resp_subset = rooki.subset(\n",
+    "resp = rooki.subset(\n",
     "    collection='cmip5.output1.MOHC.HadGEM2-ES.rcp85.mon.atmos.Amon.r1i1p1.latest.tas',\n",
     "    time='2005-01-01/2010-12-30',\n",
     ")"
@@ -68,7 +67,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "resp_subset.get()"
+    "resp.get()"
    ]
   },
   {
@@ -84,7 +83,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "resp_subset.get()[1]"
+    "resp.get()[0]"
    ]
   },
   {
@@ -100,7 +99,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "out = resp_subset.get(asobj=True)[1]"
+    "out = resp.get(asobj=True)[0]"
    ]
   },
   {
@@ -148,7 +147,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "wf_tree = {\n",
+    "wf_doc = {\n",
     "    'doc': \"tree workflow with diff operator\",\n",
     "    'inputs': {\n",
     "        'inm': ['cmip5.output1.INM.inmcm4.rcp45.mon.ocean.Omon.r1i1p1.latest.zostoga'],\n",
@@ -189,8 +188,8 @@
    "outputs": [],
    "source": [
     "import json\n",
-    "wf_tree_json = json.dumps(wf_tree)\n",
-    "wf_tree_json"
+    "wf_json = json.dumps(wf_doc)\n",
+    "wf_json"
    ]
   },
   {
@@ -199,7 +198,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "resp_wf = rooki.orchestrate(workflow=wf_tree_json)"
+    "resp = rooki.orchestrate(workflow=wf_json)"
    ]
   },
   {
@@ -208,7 +207,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "resp_wf.get()"
+    "resp.get()"
    ]
   },
   {
@@ -224,7 +223,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "out = resp_subset.get(asobj=True)[1]\n",
+    "out = resp.get(asobj=True)[0]\n",
     "out[0]"
    ]
   }

--- a/rook/processes/wps_average.py
+++ b/rook/processes/wps_average.py
@@ -11,7 +11,7 @@ class Average(Process):
                          data_type='string',
                          default='cmip5.output1.MOHC.HadGEM2-ES.rcp85.mon.atmos.Amon.r1i1p1.latest.tas',
                          min_occurs=1,
-                         max_occurs=10,),
+                         max_occurs=1,),
             LiteralInput('axes', 'Axes',
                          abstract='Please choose an axes for averaging.',
                          data_type='string',
@@ -26,10 +26,7 @@ class Average(Process):
                          max_occurs=1),
         ]
         outputs = [
-            ComplexOutput('output', 'Output',
-                          as_reference=True,
-                          supported_formats=[FORMATS.TEXT]),
-            ComplexOutput('output_meta4', 'METALINK v4 output',
+            ComplexOutput('output', 'METALINK v4 output',
                           abstract='Metalink v4 document with references to NetCDF files.',
                           as_reference=True,
                           supported_formats=[FORMATS.META4]),
@@ -53,12 +50,10 @@ class Average(Process):
         collection = [dset.data for dset in request.inputs['collection']]
         if request.inputs['pre_checked'][0].data and not is_characterised(collection, require_all=True):
             raise ProcessError('Data has not been pre-checked')
-        # single netcdf file as output
-        response.outputs['output'].data = 'not working yet'
         # metalink document with collection of netcdf files
         ml4 = MetaLink4('average-result', 'Averaging result as NetCDF files.', workdir=self.workdir)
         mf = MetaFile('Text file', 'Dummy text file', fmt=FORMATS.TEXT)
         mf.data = 'not working yet'
         ml4.append(mf)
-        response.outputs['output_meta4'].data = ml4.xml
+        response.outputs['output'].data = ml4.xml
         return response

--- a/rook/processes/wps_orchestrate.py
+++ b/rook/processes/wps_orchestrate.py
@@ -14,10 +14,7 @@ class Orchestrate(Process):
                          supported_formats=[FORMATS.JSON]),
         ]
         outputs = [
-            ComplexOutput('output', 'Output',
-                          as_reference=True,
-                          supported_formats=[FORMATS.NETCDF]),
-            ComplexOutput('output_meta4', 'METALINK v4 output',
+            ComplexOutput('output', 'METALINK v4 output',
                           abstract='Metalink v4 document with references to NetCDF files.',
                           as_reference=True,
                           supported_formats=[FORMATS.META4]),
@@ -39,13 +36,11 @@ class Orchestrate(Process):
         wf = workflow.WorkflowRunner(
             output_dir=self.workdir)
         output = wf.run(request.inputs['workflow'][0].file)
-        # single netcdf file as output
-        response.outputs['output'].file = output[0]
         # metalink document with collection of netcdf files
         ml4 = MetaLink4('workflow-result', 'Workflow result as NetCDF files.', workdir=self.workdir)
         for ncfile in output:
             mf = MetaFile('NetCDF file', 'NetCDF file', fmt=FORMATS.NETCDF)
             mf.file = ncfile
             ml4.append(mf)
-        response.outputs['output_meta4'].data = ml4.xml
+        response.outputs['output'].data = ml4.xml
         return response

--- a/rook/processes/wps_subset.py
+++ b/rook/processes/wps_subset.py
@@ -36,11 +36,7 @@ class Subset(Process):
                          max_occurs=1),
         ]
         outputs = [
-            ComplexOutput('output', 'Output',
-                          abstract='A single NetCDF file.',
-                          as_reference=True,
-                          supported_formats=[FORMATS.NETCDF]),
-            ComplexOutput('output_meta4', 'METALINK v4 output',
+            ComplexOutput('output', 'METALINK v4 output',
                           abstract='Metalink v4 document with references to NetCDF files.',
                           as_reference=True,
                           supported_formats=[FORMATS.META4]),
@@ -84,12 +80,11 @@ class Subset(Process):
         kwargs = parameterise.parameterise(**subset_args)
         kwargs.update(config_args)
         result = subset(**kwargs)
-        response.outputs['output'].file = result.file_paths[0]
         # metalink document with collection of netcdf files
         ml4 = MetaLink4('subset-result', 'Subsetting result as NetCDF files.', workdir=self.workdir)
         for ncfile in result.file_paths:
             mf = MetaFile('NetCDF file', 'NetCDF file', fmt=FORMATS.NETCDF)
             mf.file = ncfile
             ml4.append(mf)
-        response.outputs['output_meta4'].data = ml4.xml
+        response.outputs['output'].data = ml4.xml
         return response

--- a/tests/test_wps_orchestrate.py
+++ b/tests/test_wps_orchestrate.py
@@ -5,23 +5,12 @@ from .common import get_output, resource_file, PYWPS_CFG
 from rook.processes.wps_orchestrate import Orchestrate
 
 
-def test_wps_orchestrate_simple():
+def test_wps_orchestrate():
     client = client_for(Service(processes=[Orchestrate()], cfgfiles=[PYWPS_CFG]))
-    datainputs = "workflow=@xlink:href=file://{0};mode=simple".format(
-        resource_file('subset_simple_wf.json'))
-    resp = client.get(
-        "?service=WPS&request=Execute&version=1.0.0&identifier=orchestrate&datainputs={}".format(
-            datainputs))
-    assert_response_success(resp)
-    assert 'tas_mon_HadGEM2-ES_rcp85_r1i1p1_20850116-21201216.nc' in get_output(resp.xml)['output']
-
-
-def test_wps_orchestrate_tree():
-    client = client_for(Service(processes=[Orchestrate()], cfgfiles=[PYWPS_CFG]))
-    datainputs = "workflow=@xlink:href=file://{0};mode=tree".format(
+    datainputs = "workflow=@xlink:href=file://{0}".format(
         resource_file('subset_wf_1.json'))
     resp = client.get(
         "?service=WPS&request=Execute&version=1.0.0&identifier=orchestrate&datainputs={}".format(
             datainputs))
     assert_response_success(resp)
-    assert 'tas_mon_HadGEM2-ES_rcp85_r1i1p1_20850116-21201216.nc' in get_output(resp.xml)['output']
+    assert 'meta4' in get_output(resp.xml)['output']

--- a/tests/test_wps_subset.py
+++ b/tests/test_wps_subset.py
@@ -17,7 +17,7 @@ def test_wps_subset_with_time():
         "?service=WPS&request=Execute&version=1.0.0&identifier=subset&datainputs={}".format(
             datainputs))
     assert_response_success(resp)
-    assert 'tas_mon_HadGEM2-ES_rcp85_r1i1p1_20850116-21201216.nc' in get_output(resp.xml)['output']
+    assert 'meta4' in get_output(resp.xml)['output']
 
 
 def test_wps_subset_missing_collection():


### PR DESCRIPTION
## Overview

This PR keeps only the metalink output parameter in all wps processes. Update notebook example and pymetalink library.

## Related Issue / Discussion

https://github.com/roocs/34e-mngmt/issues/42

## Additional Information


