### PR TITLE
using c3s-cmip5 data as default

### DIFF
--- a/etc/roocs-dev.ini
+++ b/etc/roocs-dev.ini
@@ -1,0 +1,8 @@
+[project:cmip5]
+base_dir = /Users/pingu/data/mini-esgf-data/test_data/badc/cmip5/data
+
+[project:c3s-cmip5]
+base_dir = /Users/pingu/data/mini-esgf-data//test_data/group_workspaces/jasmin2/cp4cds1/vol1/data
+
+[project:cordex]
+base_dir = /Users/pingu/data/mini-esgf-data/test_data/group_workspaces/jasmin2/cp4cds1/data

--- a/etc/roocs.ini
+++ b/etc/roocs.ini
@@ -1,5 +1,0 @@
-[project:cmip5]
-base_dir = /Users/pingu/data/mini-esgf-data/test_data/badc/cmip5/data
-
-[project:cordex]
-base_dir = /Users/pingu/data/mini-esgf-data/test_data/group_workspaces/jasmin2/cp4cds1/data/c3s-cordex

--- a/notebooks/rook-demo.ipynb
+++ b/notebooks/rook-demo.ipynb
@@ -56,8 +56,8 @@
    "outputs": [],
    "source": [
     "resp = rooki.subset(\n",
-    "    collection='cmip5.output1.MOHC.HadGEM2-ES.rcp85.mon.atmos.Amon.r1i1p1.latest.tas',\n",
-    "    time='2005-01-01/2010-12-30',\n",
+    "    collection='c3s-cmip5.output1.ICHEC.EC-EARTH.historical.day.atmos.day.r1i1p1.tas.latest',\n",
+    "    time='1860-01-01/1900-12-30',\n",
     ")"
    ]
   },

--- a/rook/processes/wps_average.py
+++ b/rook/processes/wps_average.py
@@ -9,7 +9,7 @@ class Average(Process):
         inputs = [
             LiteralInput('collection', 'Collection',
                          data_type='string',
-                         default='cmip5.output1.MOHC.HadGEM2-ES.rcp85.mon.atmos.Amon.r1i1p1.latest.tas',
+                         default='c3s-cmip5.output1.ICHEC.EC-EARTH.historical.day.atmos.day.r1i1p1.tas.latest',
                          min_occurs=1,
                          max_occurs=1,),
             LiteralInput('axes', 'Axes',

--- a/rook/processes/wps_subset.py
+++ b/rook/processes/wps_subset.py
@@ -12,12 +12,12 @@ class Subset(Process):
     def __init__(self):
         inputs = [
             LiteralInput('collection', 'Collection',
-                         abstract='cmip5.output1.MOHC.HadGEM2-ES.rcp85.mon.atmos.Amon.r1i1p1.latest.tas',
+                         abstract='c3s-cmip5.output1.ICHEC.EC-EARTH.historical.day.atmos.day.r1i1p1.tas.latest',
                          data_type='string',
                          min_occurs=1,
                          max_occurs=1,),
             LiteralInput('time', 'Time Period',
-                         abstract='Example: 2085-01-01/2120-12-30',
+                         abstract='Example: 1860-01-01/1900-12-30',
                          data_type='string',
                          min_occurs=0,
                          max_occurs=1,),

--- a/tests/test_wps_average.py
+++ b/tests/test_wps_average.py
@@ -7,7 +7,7 @@ from rook.processes.wps_average import Average
 
 def test_wps_average():
     client = client_for(Service(processes=[Average()]))
-    datainputs = "data_ref=cmip5.output1.MOHC.HadGEM2-ES.rcp85.mon.atmos.Amon.r1i1p1.latest.tas"
+    datainputs = "data_ref=c3s-cmip5.output1.ICHEC.EC-EARTH.historical.day.atmos.day.r1i1p1.tas.latest"
     resp = client.get(
         "?service=WPS&request=Execute&version=1.0.0&identifier=average&datainputs={}".format(
             datainputs))

--- a/tests/test_wps_subset.py
+++ b/tests/test_wps_subset.py
@@ -11,8 +11,8 @@ from rook.processes.wps_subset import Subset
 
 def test_wps_subset_with_time():
     client = client_for(Service(processes=[Subset()], cfgfiles=[PYWPS_CFG]))
-    datainputs = "collection=cmip5.output1.MOHC.HadGEM2-ES.rcp85.mon.atmos.Amon.r1i1p1.latest.tas"
-    datainputs += ";time=2085-01-01/2120-12-30"
+    datainputs = "collection=c3s-cmip5.output1.ICHEC.EC-EARTH.historical.day.atmos.day.r1i1p1.tas.latest"
+    datainputs += ";time=1860-01-01/1900-12-30"
     resp = client.get(
         "?service=WPS&request=Execute&version=1.0.0&identifier=subset&datainputs={}".format(
             datainputs))
@@ -22,7 +22,7 @@ def test_wps_subset_with_time():
 
 def test_wps_subset_missing_collection():
     client = client_for(Service(processes=[Subset()], cfgfiles=[PYWPS_CFG]))
-    # datainputs = "collection=cmip5.output1.MOHC.HadGEM2-ES.rcp85.mon.atmos.Amon.r1i1p1.latest.tas"
+    # datainputs = "collection=c3s-cmip5.output1.ICHEC.EC-EARTH.historical.day.atmos.day.r1i1p1.tas.latest"
     datainputs = ""
     resp = client.get(
         "?service=WPS&request=Execute&version=1.0.0&identifier=subset&datainputs={}".format(


### PR DESCRIPTION
## Overview

This PR updates the wps abstracts with c3s-cmip5 default data.

Changes:

* Updated demo notebook.
* Updated tests.
* Updates mini-esgf-data.

## Related Issue / Discussion

## Additional Information

