### PR TITLE
using patched clisops, update conda env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,15 @@ language: python
 os:
   - linux
 python:
-  - "3.6"
+  # - "3.6"
   - "3.7"
 # branches:
 #   only:
 #     - master
 jobs:
   include:
-    - env: ALLOW_FAIL=true
-      python: "3.8"
+    # - env: ALLOW_FAIL=true
+    #  python: "3.8"
   allow_failures:
     - env: ALLOW_FAIL=true
 

--- a/env.yml
+++ b/env.yml
@@ -3,123 +3,127 @@ channels:
   - conda-forge
   - defaults
 dependencies:
+  - _libgcc_mutex=0.1=conda_forge
+  - _openmp_mutex=4.5=1_gnu
   - attrs=20.2.0=pyh9f0ad1d_0
   - bokeh=2.2.1=py37hc8dfbb8_0
-  - brotlipy=0.7.0=py37h9bfed18_1000
-  - bzip2=1.0.8=haf1e3a3_3
-  - c-ares=1.16.1=haf1e3a3_3
+  - brotlipy=0.7.0=py37h8f50634_1000
+  - bzip2=1.0.8=h516909a_3
+  - c-ares=1.16.1=h516909a_3
   - ca-certificates=2020.6.20=hecda079_0
   - certifi=2020.6.20=py37hc8dfbb8_0
-  - cffi=1.14.1=py37hf5b7abd_0
-  - cftime=1.2.1=py37h5be27a9_0
+  - cffi=1.14.3=py37h2b28604_0
+  - cftime=1.2.1=py37h03ebfcd_0
   - cfunits=3.2.9=pyh9f0ad1d_0
   - chardet=3.0.4=py37hc8dfbb8_1006
   - click=7.1.2=pyh9f0ad1d_0
   - cloudpickle=1.6.0=py_0
-  - cryptography=3.1=py37h94e4008_0
-  - curl=7.71.1=hcb81553_5
-  - cytoolz=0.10.1=py37h0b31af3_0
+  - cryptography=3.1=py37hb09aad4_0
+  - curl=7.71.1=he644dc0_5
+  - cytoolz=0.10.1=py37h516909a_0
   - dask=2.26.0=py_0
   - dask-core=2.26.0=py_0
   - decorator=4.4.2=py_0
   - distributed=2.26.0=py37hc8dfbb8_0
-  - expat=2.2.9=hb1e8313_2
-  - freetype=2.10.2=h8da9a1a_0
+  - expat=2.2.9=he1b5a44_2
+  - freetype=2.10.2=he06d7ca_0
   - fsspec=0.8.2=py_0
-  - hdf4=4.2.13=h84186c3_1003
-  - hdf5=1.10.6=nompi_haae91d6_101
+  - hdf4=4.2.13=hf30be14_1003
+  - hdf5=1.10.6=nompi_h3c11f04_101
   - heapdict=1.0.1=py_0
-  - icu=67.1=hb1e8313_0
+  - icu=67.1=he1b5a44_0
   - idna=2.10=pyh9f0ad1d_0
   - importlib-metadata=1.7.0=py37hc8dfbb8_0
   - importlib_metadata=1.7.0=0
   - iniconfig=1.0.1=pyh9f0ad1d_0
   - jinja2=2.11.2=pyh9f0ad1d_0
-  - jpeg=9d=h0b31af3_0
+  - jpeg=9d=h516909a_0
   - jsonschema=3.2.0=py37hc8dfbb8_1
-  - krb5=1.17.1=h75d18d8_3
-  - lcms2=2.11=h174193d_0
+  - krb5=1.17.1=hfafb76e_3
+  - lcms2=2.11=hbd6801e_0
+  - ld_impl_linux-64=2.35=h769bd43_9
   - libblas=3.8.0=17_openblas
   - libcblas=3.8.0=17_openblas
-  - libcurl=7.71.1=h9bf37e3_5
-  - libcxx=10.0.1=h5f48129_0
-  - libedit=3.1.20191231=h0678c8f_2
-  - libev=4.33=haf1e3a3_1
-  - libffi=3.2.1=hb1e8313_1007
-  - libgfortran=4.0.0=3
-  - libgfortran4=7.5.0=h1565451_3
-  - libiconv=1.16=haf1e3a3_0
+  - libcurl=7.71.1=hcdd3856_5
+  - libedit=3.1.20191231=he28a2e2_2
+  - libev=4.33=h516909a_1
+  - libffi=3.2.1=he1b5a44_1007
+  - libgcc-ng=9.3.0=h24d8f2e_16
+  - libgfortran-ng=7.5.0=hdf63c60_16
+  - libgomp=9.3.0=h24d8f2e_16
+  - libiconv=1.16=h516909a_0
   - liblapack=3.8.0=17_openblas
-  - libnetcdf=4.7.4=nompi_hc5b2cf3_105
-  - libnghttp2=1.41.0=h7580e61_2
-  - libopenblas=0.3.10=openmp_h63d9170_4
-  - libpng=1.6.37=hb0a8c7a_2
-  - libspatialindex=1.9.3=h4a8c4bd_3
-  - libssh2=1.9.0=h8a08a2b_5
-  - libtiff=4.1.0=h2ae36a8_6
-  - libwebp-base=1.1.0=h0b31af3_3
-  - libxml2=2.9.10=h2c6e4a5_2
-  - libxslt=1.1.33=h29b7fa6_1
-  - llvm-openmp=10.0.1=h28b9765_0
+  - libnetcdf=4.7.4=nompi_h84807e1_105
+  - libnghttp2=1.41.0=h8cfc5f6_2
+  - libopenblas=0.3.10=pthreads_hb3c22a3_4
+  - libpng=1.6.37=hed695b0_2
+  - libspatialindex=1.9.3=he1b5a44_3
+  - libssh2=1.9.0=hab1572f_5
+  - libstdcxx-ng=9.3.0=hdf63c60_16
+  - libtiff=4.1.0=hc7e4089_6
+  - libwebp-base=1.1.0=h516909a_3
+  - libxml2=2.9.10=h68273f3_2
+  - libxslt=1.1.33=h572872d_1
   - locket=0.2.0=py_2
-  - lxml=4.5.2=py37heb1707f_0
-  - lz4-c=1.9.2=hb1e8313_3
-  - markupsafe=1.1.1=py37h9bfed18_1
+  - lxml=4.5.2=py37he3881c9_0
+  - lz4-c=1.9.2=he1b5a44_3
+  - markupsafe=1.1.1=py37h8f50634_1
   - more-itertools=8.5.0=py_0
-  - msgpack-python=1.0.0=py37ha1cc60f_1
-  - ncurses=6.2=hb1e8313_1
-  - netcdf4=1.5.4=nompi_py37h08081e3_102
+  - msgpack-python=1.0.0=py37h99015e2_1
+  - ncurses=6.2=he1b5a44_1
+  - netcdf4=1.5.4=nompi_py37hcbfd489_102
   - networkx=2.5=py_0
-  - numpy=1.19.1=py37h1efc2f6_2
+  - numpy=1.19.1=py37h7ea13bd_2
   - olefile=0.46=py_0
-  - openssl=1.1.1g=haf1e3a3_1
+  - openssl=1.1.1g=h516909a_1
   - owslib=0.20.0=py_0
   - packaging=20.4=pyh9f0ad1d_0
-  - pandas=1.1.2=py37hdadc0f0_0
+  - pandas=1.1.2=py37h3340039_0
   - partd=1.1.0=py_0
   - pathlib=1.0.1=py37hc8dfbb8_2
-  - pillow=7.2.0=py37hfd78ece_1
+  - pillow=7.2.0=py37h718be6c_1
   - pip=20.2.3=py_0
   - pluggy=0.13.1=py37hc8dfbb8_2
-  - proj=7.1.1=h45baca5_0
-  - psutil=5.7.2=py37h60d8a13_0
+  - proj=7.1.1=h966b41f_0
+  - psutil=5.7.2=py37h8f50634_0
   - py=1.9.0=pyh9f0ad1d_0
   - pycparser=2.20=pyh9f0ad1d_2
   - pyopenssl=19.1.0=py_1
   - pyparsing=2.4.7=pyh9f0ad1d_0
-  - pyproj=2.6.1.post1=py37hee79b95_2
-  - pyrsistent=0.17.3=py37h60d8a13_0
+  - pyproj=2.6.1.post1=py37h6415a23_2
+  - pyrsistent=0.17.3=py37h8f50634_0
   - pysocks=1.7.1=py37hc8dfbb8_1
   - pytest=6.0.2=py37hc8dfbb8_0
-  - python=3.7.8=hc9dea61_1_cpython
+  - python=3.7.8=h6f2ec95_1_cpython
   - python-dateutil=2.8.1=py_0
   - python_abi=3.7=1_cp37m
   - pytz=2020.1=pyh9f0ad1d_0
   - pywps=4.2.8=py37hc8dfbb8_0
-  - pyyaml=5.3.1=py37h9bfed18_0
-  - readline=8.0=h0678c8f_2
+  - pyyaml=5.3.1=py37h8f50634_0
+  - readline=8.0=he28a2e2_2
   - requests=2.24.0=pyh9f0ad1d_0
   - rtree=0.9.4=py37h8526d28_1
   - setuptools=49.6.0=py37hc8dfbb8_0
   - six=1.15.0=pyh9f0ad1d_0
   - sortedcontainers=2.2.2=pyh9f0ad1d_0
-  - sqlalchemy=1.3.19=py37h60d8a13_0
-  - sqlite=3.33.0=h960bd1c_0
+  - sqlalchemy=1.3.19=py37h8f50634_0
+  - sqlite=3.33.0=h4cf870e_0
   - tblib=1.6.0=py_0
-  - tk=8.6.10=hb0a8c7a_0
+  - tk=8.6.10=hed695b0_0
   - toml=0.10.1=pyh9f0ad1d_0
   - toolz=0.10.0=py_0
-  - tornado=6.0.4=py37h9bfed18_1
+  - tornado=6.0.4=py37h8f50634_1
   - typing_extensions=3.7.4.2=py_0
-  - udunits2=2.2.27.6=h776b7f1_1001
+  - udunits2=2.2.27.6=h4e0c4b3_1001
   - urllib3=1.25.10=py_0
   - werkzeug=1.0.1=pyh9f0ad1d_0
   - wheel=0.35.1=pyh9f0ad1d_0
   - xarray=0.16.0=py_0
-  - xz=5.2.5=haf1e3a3_1
-  - yaml=0.2.5=haf1e3a3_0
+  - xz=5.2.5=h516909a_1
+  - yaml=0.2.5=h516909a_0
   - zict=2.0.0=py_0
   - zipp=3.1.0=py_0
-  - zlib=1.2.11=h7795811_1009
-  - zstd=1.4.5=h289c70a_2
-prefix: /Users/pingu/miniconda3/envs/rook
+  - zlib=1.2.11=h516909a_1009
+  - zstd=1.4.5=h6597ccf_2
+prefix: /usr/local/envs/rook
+

--- a/environment.yml
+++ b/environment.yml
@@ -4,8 +4,8 @@ channels:
 - defaults
 dependencies:
 - pip
-- python>=3.6,<3.8
-- pywps>=4.2.8,<4.3
+- python=3.7 # >=3.6,<3.8
+- pywps=4.2.8 # >=4.2.8,<4.3
 - jinja2
 - click
 - psutil
@@ -16,9 +16,9 @@ dependencies:
 - cfunits
 - cftime>=1.2.1
 - udunits2>=2.2
-- xarray>=0.15
-- dask
-- netcdf4
+- xarray>=0.16
+- dask>=2.26
+- netcdf4>=1.4
 # - clisops>=0.3.0,<0.4
 # workflow
 - networkx

--- a/etc/debug.cfg
+++ b/etc/debug.cfg
@@ -1,4 +1,4 @@
 [logging]
 level = DEBUG
-#cleantempdir = false
-#sethomedir = true
+cleantempdir = false
+sethomedir = true

--- a/rook/processes/wps_subset.py
+++ b/rook/processes/wps_subset.py
@@ -6,8 +6,6 @@ from pywps.app.exceptions import ProcessError
 from pywps.inout.outputs import MetaLink4, MetaFile
 
 
-from roocs_utils.parameter import parameterise
-
 import logging
 LOGGER = logging.getLogger()
 
@@ -64,8 +62,9 @@ class Subset(Process):
         # TODO: handle lazy load of daops
         from daops.ops.subset import subset
         from daops.utils import is_characterised
+        from roocs_utils.parameter import parameterise
         # show me the environment used by the process in debug mode
-        logging.debug(f"Environment used in subset: {os.environ}")
+        LOGGER.debug(f"Environment used in subset: {os.environ}")
         # from roocs_utils.exceptions import InvalidParameterValue, MissingParameterValue
         collection = [dset.data for dset in request.inputs['collection']]
         if request.inputs['pre_checked'][0].data and not is_characterised(collection, require_all=True):

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(name='rook',
       install_requires=[
           reqs,
           'roocs_utils @ git+https://github.com/roocs/roocs-utils.git',
-          'clisops @ git+https://github.com/roocs/clisops.git',
+          'clisops @ git+https://github.com/roocs/clisops.git@pingudev',
           'daops @ git+https://github.com/roocs/daops.git',
       ],
       extras_require={

--- a/spec-list.txt
+++ b/spec-list.txt
@@ -77,7 +77,7 @@ https://conda.anaconda.org/conda-forge/noarch/werkzeug-1.0.1-pyh9f0ad1d_0.tar.bz
 https://conda.anaconda.org/conda-forge/noarch/wheel-0.35.1-pyh9f0ad1d_0.tar.bz2
 https://conda.anaconda.org/conda-forge/noarch/zipp-3.1.0-py_0.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/certifi-2020.6.20-py37hc8dfbb8_0.tar.bz2
-https://conda.anaconda.org/conda-forge/linux-64/cffi-1.14.1-py37h2b28604_0.tar.bz2
+https://conda.anaconda.org/conda-forge/linux-64/cffi-1.14.3-py37h2b28604_0.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/chardet-3.0.4-py37hc8dfbb8_1006.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/cytoolz-0.10.1-py37h516909a_0.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/importlib-metadata-1.7.0-py37hc8dfbb8_0.tar.bz2


### PR DESCRIPTION
## Overview

This PR uses a patched version of clisops to avoid process blocking: 
https://github.com/roocs/clisops/pull/55

Updated conda env. Testing only with Python 3.7


## Related Issue / Discussion

## Additional Information


