### PR TITLE
add test for time invariant dataset

### DIFF
--- a/tests/test_wps_subset.py
+++ b/tests/test_wps_subset.py
@@ -55,3 +55,16 @@ def test_wps_subset_missing_collection():
         )
     )
     assert_process_exception(resp, code="MissingParameterValue")
+
+
+def test_wps_subset_time_invariant_dataset():
+    client = client_for(Service(processes=[Subset()], cfgfiles=[PYWPS_CFG]))
+    datainputs = "collection=CMIP6.ScenarioMIP.IPSL.IPSL-CM6A-LR.ssp119.r1i1p1f1.fx.mrsofc.gr.v20190410"
+    datainputs += ";area=1,1,300,89"
+    resp = client.get(
+        "?service=WPS&request=Execute&version=1.0.0&identifier=subset&datainputs={}".format(
+            datainputs
+        )
+    )
+    assert_response_success(resp)
+    assert "meta4" in get_output(resp.xml)["output"]


### PR DESCRIPTION
## Overview

Adds a test for a time invariant dataset. Works with changes made to file name template in the equivalent `daops`, `clisops` and `roocs-utils` branches (`test_time_invariant_datasets`, `test_time_invariant_datasets` and `time_invariant_datasets`)
