### PR TITLE
quick fix: disable apply_fixes in workflow

### DIFF
--- a/rook/operator.py
+++ b/rook/operator.py
@@ -13,10 +13,10 @@ class Operator(object):
     # Sub-classes require "prefix" property
     prefix = NotImplemented
 
-    def __init__(self, output_dir, apply_fixes=True):
+    def __init__(self, output_dir, apply_fixes=False):
         self.config = {
             "output_dir": output_dir,
-            # 'apply_fixes': apply_fixes
+            "apply_fixes": apply_fixes,
             # 'original_files': original_files
             # 'chunk_rules': dconfig.chunk_rules,
             # 'filenamer': dconfig.filenamer,

--- a/rook/workflow.py
+++ b/rook/workflow.py
@@ -31,7 +31,9 @@ def replace_inputs(wfdoc):
                 input_id = arg.split("/")[1]
                 steps[step_id]["in"][arg_id] = wfdoc["inputs"][input_id]
                 # apply fixed only for input datasets
-                steps[step_id]["in"]["apply_fixes"] = True
+                # steps[step_id]["in"]["apply_fixes"] = True
+                # quick-fix for issue #110
+                steps[step_id]["in"]["apply_fixes"] = False
     LOGGER.debug(f"steps: {steps}")
     return steps
 


### PR DESCRIPTION
## Overview

This PR is a workaround for issue #110. 

Changes:

* Disabled `apply_fixes` in workflow.

## Related Issue / Discussion

#110

## Additional Information


