### PR TITLE
Issue/108/subset alignment fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,10 @@ dask[complete]
 netcdf4
 python-dateutil>=2.8.1
 # daops>=0.3.0
+daops @ git+https://github.com/roocs/daops.git
 # clisops>=0.4.0
+clisops @ git+https://github.com/roocs/clisops.git
 # roocs-utils>=0.1.5
+roocs-utils @ git+https://github.com/roocs/roocs-utils.git@master#egg=roocs-utils
 prov>=2.0.0
 pydot

--- a/rook/director/alignment.py
+++ b/rook/director/alignment.py
@@ -37,7 +37,7 @@ class SubsetAlignmentChecker:
         # get start and end times from the time dimension in the file
 
         # convert url to file path if needed
-        if fpath.startswith("https"):
+        if fpath.startswith("http"):
             fpath = url_to_file_path(fpath)
 
         ds = xr.open_dataset(fpath, use_cftime=True)

--- a/rook/director/alignment.py
+++ b/rook/director/alignment.py
@@ -1,7 +1,9 @@
 import os
+import xarray as xr
 
 import dateutil.parser as parser
 from roocs_utils.parameter import time_parameter
+from roocs_utils.utils.time_utils import to_isoformat
 
 
 class SubsetAlignmentChecker:
@@ -10,7 +12,7 @@ class SubsetAlignmentChecker:
         self.is_aligned = False
         self.aligned_files = []
 
-        self._deduce_alignment(inputs)  # needs inputs - where are they coming from
+        self._deduce_alignment(inputs)
 
     def _deduce_alignment(self, inputs):
         # At present, we reject alignment if any "area" or "level" subset is requested
@@ -31,23 +33,11 @@ class SubsetAlignmentChecker:
             self._check_time_alignment(start, end)
 
     def _get_file_times(self, fpath):
-        # Use file name to get start and end (instead of reading files)
-        start, end = os.path.basename(fpath).split(".")[-2].split("_")[-1].split("-")
-
-        # parser should parse YYYYMM and YYYYMMDDhhmm but doesn't
-        start, end = [
-            each[:6] + "01" + each[6:] if len(each) == 6 else each
-            for each in (start, end)
-        ]
-        start, end = [
-            each[:8] + "T" + each[8:] if len(each) > 8 else each
-            for each in (start, end)
-        ]
-        start, end = (
-            parser.isoparse(start).isoformat(),
-            parser.isoparse(end).isoformat(),
-        )
-
+        # get start and end times from the time dimension in the file
+        ds = xr.open_dataset(fpath, use_cftime=True)
+        start = to_isoformat(ds.time.values[0])
+        end = to_isoformat(ds.time.values[-1])
+        ds.close()
         return start, end
 
     def _check_time_alignment(self, start, end):
@@ -70,6 +60,7 @@ class SubsetAlignmentChecker:
 
         # First of all truncate requested range to actual range if it extends
         # beyond the actual range in the files
+
         start_in_files, _ = self._get_file_times(self.input_files[0])
         _, end_in_files = self._get_file_times(self.input_files[-1])
 
@@ -94,10 +85,9 @@ class SubsetAlignmentChecker:
             if fend == end:
                 matches += 1
 
-            if fstart >= start or fend <= end:
+            if fstart >= start or end <= fend:
                 self.aligned_files.append(fpath)
 
-        # If there were not
         if matches != 2:
             self.aligned_files.clear()
             return

--- a/rook/director/director.py
+++ b/rook/director/director.py
@@ -111,7 +111,7 @@ class Director:
             coll = [dset1, dset2]
             inputs = {'time': '1999-01-01/2000-12-31'}
 
-        If dset1 and dset2 have files that exactly start/end on those times, then:
+        If input datasets have files that exactly start/end on those times, then:
             - return True (and the original files are provided).
 
         If, however, there are other subset options OR one of the datasets does not

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ replace = "version": "{new_version}",
 addopts =
 	--strict
 	--tb=native
-	# tests/
+	tests/
 python_files = test_*.py
 markers =
 	online: mark test to need internet connection

--- a/setup.py
+++ b/setup.py
@@ -50,12 +50,7 @@ setup(
     keywords="wps pywps birdhouse rook",
     packages=find_packages(),
     include_package_data=True,
-    install_requires=[
-        reqs,
-        "daops @ git+https://github.com/roocs/daops.git",
-        "clisops @ git+https://github.com/roocs/clisops.git",
-        "roocs-utils @ git+https://github.com/roocs/roocs-utils.git",
-    ],
+    install_requires=[reqs],
     extras_require={
         "dev": dev_reqs,  # pip install ".[dev]"
     },

--- a/tests/test_director/test_alignment.py
+++ b/tests/test_director/test_alignment.py
@@ -22,8 +22,6 @@ class TestYearMonth:
         sac = SubsetAlignmentChecker(self.test_paths, inputs)
         assert sac.is_aligned is True
         assert sac.aligned_files == self.test_paths
-        print(sac.aligned_files)
-        print(self.test_paths)
 
     def test_area_subset(self):
         inputs = {"area": "0.,49.,10.,65"}
@@ -45,13 +43,17 @@ class TestYearMonth:
 
     def test_time_subset_match(self):
         inputs = {"time": "1859-12/2005-11"}
+        # start defaults to 1st of month
+        # end defaults to 30th of month
+        # the start and end day of dataset is 16th so this results in a requested time range outside of the actual range
+        # so this is aligned.
         sac = SubsetAlignmentChecker(self.test_paths, inputs)
         assert sac.is_aligned is True
         assert sac.aligned_files == self.test_paths
 
 
-class TestYearMonthDay:
-    """ Tests with year month and day """
+class TestYearMonthDay1200:
+    """ Tests with year month and day for dataset with a 12:00:00 time step """
 
     test_path = (
         "tests/mini-esgf-data/test_data/gws/nopw/j04/cp4cds1_vol1/data/c3s-cmip5/output1/ICHEC/"
@@ -163,3 +165,39 @@ class TestYearMonthDay:
         sac = SubsetAlignmentChecker(self.test_paths, inputs)
         assert sac.is_aligned is False
         assert sac.aligned_files == []
+
+
+class TestYearMonthDay0000:
+    """ Tests with year month and day for dataset with a 00:00:00 time step """
+
+    test_path = (
+        "tests/mini-esgf-data/test_data/badc/cmip5/data/cmip5/output1/MOHC/HadGEM2-ES/historical/mon/atmos/Amon"
+        "/r1i1p1/latest/tas/*.nc"
+    )
+    test_paths = sorted(glob.glob(test_path))
+
+    # actual range in files is 185912-200511
+
+    def test_time_subset_matches_no_hour(self):
+        """Tests alignment of full dataset where:
+        - Real range: 1859-12-16T00:00:00 to 2005-11-16T00:00:00
+        - Start: 1859-12-16 (start without hour)
+        - End:   2005-11-16 (end without hour)
+
+        """
+        inputs = {"time": "1859-12-16/2005-11-16"}
+        sac = SubsetAlignmentChecker(self.test_paths, inputs)
+        # aligns because default is timestamp of 00:00:00 if not provided
+        assert sac.is_aligned is True
+        assert sac.aligned_files == self.test_paths
+
+    def test_time_subset_matches_including_hour(self):
+        """Tests alignment of full dataset where:
+        - Real range: 1859-12-16T00:00:00 to 2005-11-16T00:00:00
+        - Start: 1859-12-16T00:00:00 (exact start)
+        - End:   2005-11-16T00:00:00 (exact end)
+        """
+        inputs = {"time": "1859-12-16T00:00:00/2005-11-16T00:00:00"}
+        sac = SubsetAlignmentChecker(self.test_paths, inputs)
+        assert sac.is_aligned is True
+        assert sac.aligned_files == self.test_paths

--- a/tests/test_director/test_alignment.py
+++ b/tests/test_director/test_alignment.py
@@ -7,12 +7,15 @@ from rook.director.alignment import SubsetAlignmentChecker
 
 
 class TestYearMonth:
+    """ Tests with year and month only, not day"""
 
     test_path = (
         "tests/mini-esgf-data/test_data/badc/cmip5/data/cmip5/output1/MOHC/HadGEM2-ES/historical/mon/atmos/Amon"
         "/r1i1p1/latest/tas/*.nc"
     )
     test_paths = sorted(glob.glob(test_path))
+
+    # actual range in files is 185912-200511
 
     def test_no_subset(self):
         inputs = {}
@@ -29,25 +32,26 @@ class TestYearMonth:
         assert sac.aligned_files == []
 
     def test_time_subset_no_match(self):
-        inputs = {"time": "1886-01-01/1930-11-01"}
+        inputs = {"time": "1886-01/1930-11"}
         sac = SubsetAlignmentChecker(self.test_paths, inputs)
         assert sac.is_aligned is False
         assert sac.aligned_files == []
 
     def test_time_subset_one_match(self):
-        inputs = {"time": "1886-01-01/1984-11-01"}
+        inputs = {"time": "1886-01/1984-11"}
         sac = SubsetAlignmentChecker(self.test_paths, inputs)
         assert sac.is_aligned is False
         assert sac.aligned_files == []
 
     def test_time_subset_match(self):
-        inputs = {"time": "1859-12-01/2005-11-01"}
+        inputs = {"time": "1859-12/2005-11"}
         sac = SubsetAlignmentChecker(self.test_paths, inputs)
         assert sac.is_aligned is True
         assert sac.aligned_files == self.test_paths
 
 
 class TestYearMonthDay:
+    """ Tests with year month and day """
 
     test_path = (
         "tests/mini-esgf-data/test_data/gws/nopw/j04/cp4cds1_vol1/data/c3s-cmip5/output1/ICHEC/"
@@ -76,40 +80,53 @@ class TestYearMonthDay:
         assert sac.aligned_files == []
 
     def test_time_subset_one_match(self):
-        inputs = {"time": "1886-01-01/1900-01-01"}
+        inputs = {"time": "1900-01-01/1930-11-01"}
         sac = SubsetAlignmentChecker(self.test_paths, inputs)
         assert sac.is_aligned is False
         assert sac.aligned_files == []
 
-    def test_time_subset_matches_exact_range(self):
+    def test_time_subset_matches_one_file(self):
+        inputs = {"time": "1900-01-01T12:00:00/1909-12-31T12:00:00"}
+        sac = SubsetAlignmentChecker(self.test_paths, inputs)
+        assert sac.is_aligned is True
+        assert sac.aligned_files == [
+            "tests/mini-esgf-data/test_data/gws/nopw/j04/cp4cds1_vol1/data/c3s-cmip5"
+            "/output1/ICHEC/EC-EARTH/historical/day/atmos/day/r1i1p1/tas/v20131231"
+            "/tas_day_EC-EARTH_historical_r1i1p1_19000101-19091231.nc"
+        ]
+
+    def test_time_subset_matches_exact_range_excluding_hour(self):
         """Tests alignment of full dataset where:
         - Real range: 18500101-20091130
         - Start: 18500101 (exact start)
         - End:   20091130 (exact end)
+
+        Is not aligned as the hour is set to 00:00:00 when not provided and the time stamp
+        for these files is 12:00:00.
         """
         inputs = {"time": "1850-01-01/2009-11-30"}
         sac = SubsetAlignmentChecker(self.test_paths, inputs)
-        assert sac.is_aligned is True
-        assert sac.aligned_files == self.test_paths
+        assert sac.is_aligned is False
+        assert sac.aligned_files == []
 
     def test_time_subset_matches_before_to_end(self):
         """Tests alignment of full dataset where:
         - Real range: 18500101-20091130
         - Start: 17000101 (before)
-        - End:   20091130 (exact end)
+        - End:   20091130T12:00:00 (exact end)
         """
-        inputs = {"time": "1700-01-01/2009-11-30"}
+        inputs = {"time": "1700-01-01/2009-11-30T12:00:00"}
         sac = SubsetAlignmentChecker(self.test_paths, inputs)
         assert sac.is_aligned is True
         assert sac.aligned_files == self.test_paths
 
-    def test_time_subset_mathces_start_to_after(self):
+    def test_time_subset_matches_start_to_after(self):
         """Tests alignment of full dataset where:
         - Real range: 18500101-20091130
-        - Start: 18500101 (exact start)
+        - Start: 18500101T12:00:00 (exact start)
         - End:   29991230 (after)
         """
-        inputs = {"time": "1850-01-01/2999-12-30"}
+        inputs = {"time": "1850-01-01T12:00:00/2999-12-30"}
         sac = SubsetAlignmentChecker(self.test_paths, inputs)
         assert sac.is_aligned is True
         assert sac.aligned_files == self.test_paths
@@ -125,27 +142,49 @@ class TestYearMonthDay:
         assert sac.is_aligned is True
         assert sac.aligned_files == self.test_paths
 
+    def test_time_subset_matches_including_hour(self):
+        """Tests alignment of full dataset where:
+        - Real range: 1850-01-01T12:00:00 to 2009-11-30T12:00:00
+        - Start: 1850-01-01T12:00:00 (exact start)
+        - End:   2009-11-30T12:00:00 (exact end)
+        """
+        inputs = {"time": "1850-01-01T12:00:00/2009-11-30T12:00:00"}
+        sac = SubsetAlignmentChecker(self.test_paths, inputs)
+        assert sac.is_aligned is True
+        assert sac.aligned_files == self.test_paths
 
-def dummy_time_parse(fpath):
-    start, end = os.path.basename(fpath).split(".")[-2].split("_")[-1].split("-")
-    start, end = [
-        each[:6] + "01" + each[6:] if len(each) == 6 else each for each in (start, end)
-    ]
-    start, end = [
-        each[:8] + "T" + each[8:] if len(each) > 8 else each for each in (start, end)
-    ]
-    start, end = (
-        parser.isoparse(start).isoformat(),
-        parser.isoparse(end).isoformat(),
-    )
-    return start, end
+    def test_time_subset_no_match_including_hour(self):
+        """Tests not aligned when time not aligned with file:
+        - Real range: 1850-01-01T12:00:00 to 2009-11-30T12:00:00
+        - Start: 1850-01-01T14:00:00 (start)
+        - End:   2009-11-30T12:00:00 (exact end)
+        """
+        inputs = {"time": "1850-01-01T14:00:00/2009-11-30T12:00:00"}
+        sac = SubsetAlignmentChecker(self.test_paths, inputs)
+        assert sac.is_aligned is False
+        assert sac.aligned_files == []
 
 
-def test_parse_YMDhm():
-    fpath = (
-        "ScenarioMIP/AWI/AWI-CM-1-1-MR/ssp245/r1i1p1f1/3hr/tas/gn/v20190529"
-        "/tas_3hr_AWI-CM-1-1-MR_ssp245_r1i1p1f1_gn_207301010300-207401010000.nc"
-    )
-    start, end = dummy_time_parse(fpath)
-    assert start == "2073-01-01T03:00:00"
-    assert end == "2074-01-01T00:00:00"
+# def dummy_time_parse(fpath):
+#     start, end = os.path.basename(fpath).split(".")[-2].split("_")[-1].split("-")
+#     start, end = [
+#         each[:6] + "01" + each[6:] if len(each) == 6 else each for each in (start, end)
+#     ]
+#     start, end = [
+#         each[:8] + "T" + each[8:] if len(each) > 8 else each for each in (start, end)
+#     ]
+#     start, end = (
+#         parser.isoparse(start).isoformat(),
+#         parser.isoparse(end).isoformat(),
+#     )
+#     return start, end
+#
+#
+# def test_parse_YMDhm():
+#     fpath = (
+#         "ScenarioMIP/AWI/AWI-CM-1-1-MR/ssp245/r1i1p1f1/3hr/tas/gn/v20190529"
+#         "/tas_3hr_AWI-CM-1-1-MR_ssp245_r1i1p1f1_gn_207301010300-207401010000.nc"
+#     )
+#     start, end = dummy_time_parse(fpath)
+#     assert start == "2073-01-01T03:00:00"
+#     assert end == "2074-01-01T00:00:00"

--- a/tests/test_director/test_alignment.py
+++ b/tests/test_director/test_alignment.py
@@ -163,28 +163,3 @@ class TestYearMonthDay:
         sac = SubsetAlignmentChecker(self.test_paths, inputs)
         assert sac.is_aligned is False
         assert sac.aligned_files == []
-
-
-# def dummy_time_parse(fpath):
-#     start, end = os.path.basename(fpath).split(".")[-2].split("_")[-1].split("-")
-#     start, end = [
-#         each[:6] + "01" + each[6:] if len(each) == 6 else each for each in (start, end)
-#     ]
-#     start, end = [
-#         each[:8] + "T" + each[8:] if len(each) > 8 else each for each in (start, end)
-#     ]
-#     start, end = (
-#         parser.isoparse(start).isoformat(),
-#         parser.isoparse(end).isoformat(),
-#     )
-#     return start, end
-#
-#
-# def test_parse_YMDhm():
-#     fpath = (
-#         "ScenarioMIP/AWI/AWI-CM-1-1-MR/ssp245/r1i1p1f1/3hr/tas/gn/v20190529"
-#         "/tas_3hr_AWI-CM-1-1-MR_ssp245_r1i1p1f1_gn_207301010300-207401010000.nc"
-#     )
-#     start, end = dummy_time_parse(fpath)
-#     assert start == "2073-01-01T03:00:00"
-#     assert end == "2074-01-01T00:00:00"


### PR DESCRIPTION
## Overview

This PR fixes https://github.com/roocs/rook/issues/108

Changes:

* Fix subset aligner to match times of day, also fixes requirements to match up `roocs-utils` versions
* Datasets with a "12:00:00" time step for example will now be classed as not aligned if only the day of the last day in the datasets is provided e.g. 2009-11-30 as the time step will default to "00:00:00". The time must be provided or a day a date after the last one in the dataset.
* Calls `url_to_file_path()` in `_get_file_times` so that URLs can pass through `SubsetAlignmentChecker`

## Related Issue / Discussion
fixes issue https://github.com/roocs/rook/issues/108