### PR TITLE
removed xfails where not needed

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ replace = "version": "{new_version}",
 addopts =
 	--strict
 	--tb=native
-	# tests/
+	tests/
 python_files = test_*.py
 markers =
 	online: mark test to need internet connection

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -38,21 +38,19 @@ def test_build_tree():
     ]
 
 
-@pytest.mark.xfail(reason="Uses cmip5 - needs mock inventory in order to work")
-def test_run_tree_wf(fake_inv):
+def test_run_tree_wf():
     wf = workflow.WorkflowRunner(output_dir=tempfile.mkdtemp())
     output = wf.run(TREE_WF)
     assert "tas_mon_HadGEM2-ES_rcp85_r1i1p1_20850116-21201216.nc" in output[0]
 
 
-@pytest.mark.xfail(reason="Fails because of clisops subset: see rook issue: #82")
 def test_run_tree_wf_2():
     wf = workflow.WorkflowRunner(output_dir=tempfile.mkdtemp())
     output = wf.run(TREE_WF_2)
     assert "tas_mon_HadGEM2-ES_rcp85_r1i1p1_20900116-21001216.nc" in output[0]
 
 
-@pytest.mark.xfail(reason="Uses cmip5 - needs mock inventory in order to work")
+@pytest.mark.xfail(reason="Uses Diff operator - not implemented.")
 def test_run_tree_wf_3():
     wf = workflow.WorkflowRunner(output_dir=tempfile.mkdtemp())
     output = wf.run(TREE_WF_3)
@@ -82,7 +80,10 @@ def test_run_tree_wf_5():
 def test_run_tree_wf_6():
     wf = workflow.WorkflowRunner(output_dir=tempfile.mkdtemp())
     output = wf.run(TREE_WF_6)
-    assert 'https://data.mips.copernicus-climate.eu/thredds/fileServer/esg_c3s-cmip6' in output[0]
+    assert (
+        "https://data.mips.copernicus-climate.eu/thredds/fileServer/esg_c3s-cmip6"
+        in output[0]
+    )
     assert "zostoga_mon_inmcm4_rcp45_r1i1p1_20850116-21001216.nc" in output[0]
 
 
@@ -90,4 +91,7 @@ def test_run_wf_collection_only():
     wfdoc = resource_file("wf_cmip6_subset_collection_only.json")
     wf = workflow.WorkflowRunner(output_dir=tempfile.mkdtemp())
     output = wf.run(wfdoc)
-    assert "rlds_Amon_IPSL-CM6A-LR_historical_r1i1p1f1_gr_18500116-20141216.nc" in output[0]
+    assert (
+        "rlds_Amon_IPSL-CM6A-LR_historical_r1i1p1f1_gr_18500116-20141216.nc"
+        in output[0]
+    )


### PR DESCRIPTION
Remove `pytest.mark.xfail` for tests that no longer need it.

A `use_inventory` option has been implemented so that cmip5 tests don't need a mock inventory.