### PR TITLE
Gitpython testdata fix

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -13,3 +13,4 @@ cruft
 # Changing dependencies above this comment will create merge conflicts when updating the cookiecutter template with cruft. Add extra requirements below this line.
 black
 pre-commit
+GitPython==3.1.12

--- a/tests/common.py
+++ b/tests/common.py
@@ -2,6 +2,7 @@ import os
 import tempfile
 
 from jinja2 import Template
+from pathlib import Path
 from pywps import get_ElementMakerForVersion
 from pywps.app.basic import get_xpath_ns
 from pywps.tests import WpsClient, WpsTestResponse
@@ -14,6 +15,8 @@ VERSION = "1.0.0"
 WPS, OWS = get_ElementMakerForVersion(VERSION)
 xpath_ns = get_xpath_ns(VERSION)
 
+MINI_ESGF_CACHE_DIR = Path.home() / ".mini-esgf-data"
+MINI_ESGF_MASTER_DIR = os.path.join(MINI_ESGF_CACHE_DIR, "master")
 
 def write_roocs_cfg():
     cfg_templ = """
@@ -21,27 +24,27 @@ def write_roocs_cfg():
     file_size_limit = 100KB
 
     [project:cmip5]
-    base_dir = {{ base_dir }}/mini-esgf-data/test_data/badc/cmip5/data/cmip5
+    base_dir = {{ base_dir }}/test_data/badc/cmip5/data/cmip5
     use_inventory = False
 
     [project:cmip6]
-    base_dir = {{ base_dir }}/mini-esgf-data/test_data/badc/cmip6/data/CMIP6
+    base_dir = {{ base_dir }}/test_data/badc/cmip6/data/CMIP6
     use_inventory = False
 
     [project:cordex]
-    base_dir = {{ base_dir }}/mini-esgf-data/test_data/badc/cordex/data/cordex
+    base_dir = {{ base_dir }}/test_data/badc/cordex/data/cordex
     use_inventory = False
 
     [project:c3s-cmip5]
-    base_dir = {{ base_dir }}/mini-esgf-data/test_data/gws/nopw/j04/cp4cds1_vol1/data/c3s-cmip5
+    base_dir = {{ base_dir }}/test_data/gws/nopw/j04/cp4cds1_vol1/data/c3s-cmip5
 
     [project:c3s-cmip6]
-    base_dir = {{ base_dir }}/mini-esgf-data/test_data/badc/cmip6/data/CMIP6
+    base_dir = {{ base_dir }}/test_data/badc/cmip6/data/CMIP6
 
     [project:c3s-cordex]
-    base_dir = {{ base_dir }}/mini-esgf-data/test_data/gws/nopw/j04/cp4cds1_vol1/data/c3s-cordex
+    base_dir = {{ base_dir }}/test_data/gws/nopw/j04/cp4cds1_vol1/data/c3s-cordex
     """
-    cfg = Template(cfg_templ).render(base_dir=TESTS_HOME)
+    cfg = Template(cfg_templ).render(base_dir=MINI_ESGF_MASTER_DIR)
     with open(ROOCS_CFG, "w") as fp:
         fp.write(cfg)
     # point to roocs cfg in environment

--- a/tests/common.py
+++ b/tests/common.py
@@ -18,6 +18,7 @@ xpath_ns = get_xpath_ns(VERSION)
 MINI_ESGF_CACHE_DIR = Path.home() / ".mini-esgf-data"
 MINI_ESGF_MASTER_DIR = os.path.join(MINI_ESGF_CACHE_DIR, "master")
 
+
 def write_roocs_cfg():
     cfg_templ = """
     [clisops:write]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,37 @@
 import os
-
 import pytest
 
-from tests.common import write_roocs_cfg
+from git import Repo
+
+from tests.common import write_roocs_cfg, MINI_ESGF_CACHE_DIR
 
 write_roocs_cfg()
+
+TEST_DATA_REPO_URL = "https://github.com/roocs/mini-esgf-data"
 
 
 @pytest.fixture
 def fake_inv():
     os.environ["ROOK_FAKE_INVENTORY"] = "1"
+
+
+@pytest.fixture
+def load_test_data():
+    """
+    This fixture ensures that the required test data repository
+    has been cloned to the cache directory within the home directory.
+    """
+    branch = "master"
+    target = os.path.join(MINI_ESGF_CACHE_DIR, branch)
+
+    if not os.path.isdir(MINI_ESGF_CACHE_DIR):
+        os.makedirs(MINI_ESGF_CACHE_DIR)
+
+    if not os.path.isdir(target):
+        repo = Repo.clone_from(TEST_DATA_REPO_URL, target)
+        repo.git.checkout(branch)
+
+    elif os.environ.get("ROOCS_AUTO_UPDATE_TEST_DATA", "true").lower() != "false":
+        repo = Repo(target)
+        repo.git.checkout(branch)
+        repo.remotes[0].pull()

--- a/tests/test_director/test_alignment.py
+++ b/tests/test_director/test_alignment.py
@@ -183,7 +183,7 @@ class TestYearMonthDay0000:
         f"{MINI_ESGF_MASTER_DIR}/test_data/badc/cmip5/data/cmip5/output1/MOHC/HadGEM2-ES/historical/mon/atmos/Amon"
         f"/r1i1p1/latest/tas/*.nc"
     )
-    
+
     @pytest.fixture
     def get_files(self, load_test_data):
         test_paths = sorted(glob.glob(self.test_path))

--- a/tests/test_director/test_alignment.py
+++ b/tests/test_director/test_alignment.py
@@ -3,6 +3,7 @@ import os
 
 import dateutil.parser as parser
 
+from tests.common import MINI_ESGF_MASTER_DIR
 from rook.director.alignment import SubsetAlignmentChecker
 
 
@@ -10,38 +11,38 @@ class TestYearMonth:
     """ Tests with year and month only, not day"""
 
     test_path = (
-        "tests/mini-esgf-data/test_data/badc/cmip5/data/cmip5/output1/MOHC/HadGEM2-ES/historical/mon/atmos/Amon"
-        "/r1i1p1/latest/tas/*.nc"
+        f"{MINI_ESGF_MASTER_DIR}/test_data/badc/cmip5/data/cmip5/output1/MOHC/HadGEM2-ES/historical/mon/atmos/Amon"
+        f"/r1i1p1/latest/tas/*.nc"
     )
     test_paths = sorted(glob.glob(test_path))
 
     # actual range in files is 185912-200511
 
-    def test_no_subset(self):
+    def test_no_subset(self, load_test_data):
         inputs = {}
         sac = SubsetAlignmentChecker(self.test_paths, inputs)
         assert sac.is_aligned is True
         assert sac.aligned_files == self.test_paths
 
-    def test_area_subset(self):
+    def test_area_subset(self, load_test_data):
         inputs = {"area": "0.,49.,10.,65"}
         sac = SubsetAlignmentChecker(self.test_paths, inputs)
         assert sac.is_aligned is False
         assert sac.aligned_files == []
 
-    def test_time_subset_no_match(self):
+    def test_time_subset_no_match(self, load_test_data):
         inputs = {"time": "1886-01/1930-11"}
         sac = SubsetAlignmentChecker(self.test_paths, inputs)
         assert sac.is_aligned is False
         assert sac.aligned_files == []
 
-    def test_time_subset_one_match(self):
+    def test_time_subset_one_match(self, load_test_data):
         inputs = {"time": "1886-01/1984-11"}
         sac = SubsetAlignmentChecker(self.test_paths, inputs)
         assert sac.is_aligned is False
         assert sac.aligned_files == []
 
-    def test_time_subset_match(self):
+    def test_time_subset_match(self, load_test_data):
         inputs = {"time": "1859-12/2005-11"}
         # start defaults to 1st of month
         # end defaults to 30th of month
@@ -56,48 +57,48 @@ class TestYearMonthDay1200:
     """ Tests with year month and day for dataset with a 12:00:00 time step """
 
     test_path = (
-        "tests/mini-esgf-data/test_data/gws/nopw/j04/cp4cds1_vol1/data/c3s-cmip5/output1/ICHEC/"
-        "EC-EARTH/historical/day/atmos/day/r1i1p1/tas/v20131231/*.nc"
+        f"{MINI_ESGF_MASTER_DIR}/test_data/gws/nopw/j04/cp4cds1_vol1/data/c3s-cmip5/output1/ICHEC/"
+        f"EC-EARTH/historical/day/atmos/day/r1i1p1/tas/v20131231/*.nc"
     )
     # Actual range in files is: 18500101-20091130
 
     test_paths = sorted(glob.glob(test_path))
 
-    def test_no_subset(self):
+    def test_no_subset(self, load_test_data):
         inputs = {}
         sac = SubsetAlignmentChecker(self.test_paths, inputs)
         assert sac.is_aligned is True
         assert sac.aligned_files == self.test_paths
 
-    def test_area_subset(self):
+    def test_area_subset(self, load_test_data):
         inputs = {"area": "0.,49.,10.,65"}
         sac = SubsetAlignmentChecker(self.test_paths, inputs)
         assert sac.is_aligned is False
         assert sac.aligned_files == []
 
-    def test_time_subset_no_match(self):
+    def test_time_subset_no_match(self, load_test_data):
         inputs = {"time": "1886-01-01/1930-11-01"}
         sac = SubsetAlignmentChecker(self.test_paths, inputs)
         assert sac.is_aligned is False
         assert sac.aligned_files == []
 
-    def test_time_subset_one_match(self):
+    def test_time_subset_one_match(self, load_test_data):
         inputs = {"time": "1900-01-01/1930-11-01"}
         sac = SubsetAlignmentChecker(self.test_paths, inputs)
         assert sac.is_aligned is False
         assert sac.aligned_files == []
 
-    def test_time_subset_matches_one_file(self):
+    def test_time_subset_matches_one_file(self, load_test_data):
         inputs = {"time": "1900-01-01T12:00:00/1909-12-31T12:00:00"}
         sac = SubsetAlignmentChecker(self.test_paths, inputs)
         assert sac.is_aligned is True
         assert sac.aligned_files == [
-            "tests/mini-esgf-data/test_data/gws/nopw/j04/cp4cds1_vol1/data/c3s-cmip5"
-            "/output1/ICHEC/EC-EARTH/historical/day/atmos/day/r1i1p1/tas/v20131231"
-            "/tas_day_EC-EARTH_historical_r1i1p1_19000101-19091231.nc"
+            f"{MINI_ESGF_MASTER_DIR}/test_data/gws/nopw/j04/cp4cds1_vol1/data/c3s-cmip5"
+            f"/output1/ICHEC/EC-EARTH/historical/day/atmos/day/r1i1p1/tas/v20131231"
+            f"/tas_day_EC-EARTH_historical_r1i1p1_19000101-19091231.nc"
         ]
 
-    def test_time_subset_matches_exact_range_excluding_hour(self):
+    def test_time_subset_matches_exact_range_excluding_hour(self, load_test_data):
         """Tests alignment of full dataset where:
         - Real range: 18500101-20091130
         - Start: 18500101 (exact start)
@@ -111,7 +112,7 @@ class TestYearMonthDay1200:
         assert sac.is_aligned is False
         assert sac.aligned_files == []
 
-    def test_time_subset_matches_before_to_end(self):
+    def test_time_subset_matches_before_to_end(self, load_test_data):
         """Tests alignment of full dataset where:
         - Real range: 18500101-20091130
         - Start: 17000101 (before)
@@ -122,7 +123,7 @@ class TestYearMonthDay1200:
         assert sac.is_aligned is True
         assert sac.aligned_files == self.test_paths
 
-    def test_time_subset_matches_start_to_after(self):
+    def test_time_subset_matches_start_to_after(self, load_test_data):
         """Tests alignment of full dataset where:
         - Real range: 18500101-20091130
         - Start: 18500101T12:00:00 (exact start)
@@ -133,7 +134,7 @@ class TestYearMonthDay1200:
         assert sac.is_aligned is True
         assert sac.aligned_files == self.test_paths
 
-    def test_time_subset_matches_before_to_after(self):
+    def test_time_subset_matches_before_to_after(self, load_test_data):
         """Tests alignment of full dataset where:
         - Real range: 18500101-20091130
         - Start: 17000101 (before)
@@ -144,7 +145,7 @@ class TestYearMonthDay1200:
         assert sac.is_aligned is True
         assert sac.aligned_files == self.test_paths
 
-    def test_time_subset_matches_including_hour(self):
+    def test_time_subset_matches_including_hour(self, load_test_data):
         """Tests alignment of full dataset where:
         - Real range: 1850-01-01T12:00:00 to 2009-11-30T12:00:00
         - Start: 1850-01-01T12:00:00 (exact start)
@@ -155,7 +156,7 @@ class TestYearMonthDay1200:
         assert sac.is_aligned is True
         assert sac.aligned_files == self.test_paths
 
-    def test_time_subset_no_match_including_hour(self):
+    def test_time_subset_no_match_including_hour(self, load_test_data):
         """Tests not aligned when time not aligned with file:
         - Real range: 1850-01-01T12:00:00 to 2009-11-30T12:00:00
         - Start: 1850-01-01T14:00:00 (start)
@@ -171,14 +172,14 @@ class TestYearMonthDay0000:
     """ Tests with year month and day for dataset with a 00:00:00 time step """
 
     test_path = (
-        "tests/mini-esgf-data/test_data/badc/cmip5/data/cmip5/output1/MOHC/HadGEM2-ES/historical/mon/atmos/Amon"
-        "/r1i1p1/latest/tas/*.nc"
+        f"{MINI_ESGF_MASTER_DIR}/test_data/badc/cmip5/data/cmip5/output1/MOHC/HadGEM2-ES/historical/mon/atmos/Amon"
+        f"/r1i1p1/latest/tas/*.nc"
     )
     test_paths = sorted(glob.glob(test_path))
 
     # actual range in files is 185912-200511
 
-    def test_time_subset_matches_no_hour(self):
+    def test_time_subset_matches_no_hour(self, load_test_data):
         """Tests alignment of full dataset where:
         - Real range: 1859-12-16T00:00:00 to 2005-11-16T00:00:00
         - Start: 1859-12-16 (start without hour)
@@ -191,7 +192,7 @@ class TestYearMonthDay0000:
         assert sac.is_aligned is True
         assert sac.aligned_files == self.test_paths
 
-    def test_time_subset_matches_including_hour(self):
+    def test_time_subset_matches_including_hour(self, load_test_data):
         """Tests alignment of full dataset where:
         - Real range: 1859-12-16T00:00:00 to 2005-11-16T00:00:00
         - Start: 1859-12-16T00:00:00 (exact start)

--- a/tests/test_director/test_alignment.py
+++ b/tests/test_director/test_alignment.py
@@ -1,4 +1,5 @@
 import glob
+import pytest
 import os
 
 import dateutil.parser as parser
@@ -14,43 +15,47 @@ class TestYearMonth:
         f"{MINI_ESGF_MASTER_DIR}/test_data/badc/cmip5/data/cmip5/output1/MOHC/HadGEM2-ES/historical/mon/atmos/Amon"
         f"/r1i1p1/latest/tas/*.nc"
     )
-    test_paths = sorted(glob.glob(test_path))
+
+    @pytest.fixture
+    def get_files(self, load_test_data):
+        test_paths = sorted(glob.glob(self.test_path))
+        return test_paths
 
     # actual range in files is 185912-200511
 
-    def test_no_subset(self, load_test_data):
+    def test_no_subset(self, get_files):
         inputs = {}
-        sac = SubsetAlignmentChecker(self.test_paths, inputs)
+        sac = SubsetAlignmentChecker(get_files, inputs)
         assert sac.is_aligned is True
-        assert sac.aligned_files == self.test_paths
+        assert sac.aligned_files == get_files
 
-    def test_area_subset(self, load_test_data):
+    def test_area_subset(self, get_files):
         inputs = {"area": "0.,49.,10.,65"}
-        sac = SubsetAlignmentChecker(self.test_paths, inputs)
+        sac = SubsetAlignmentChecker(get_files, inputs)
         assert sac.is_aligned is False
         assert sac.aligned_files == []
 
-    def test_time_subset_no_match(self, load_test_data):
+    def test_time_subset_no_match(self, get_files):
         inputs = {"time": "1886-01/1930-11"}
-        sac = SubsetAlignmentChecker(self.test_paths, inputs)
+        sac = SubsetAlignmentChecker(get_files, inputs)
         assert sac.is_aligned is False
         assert sac.aligned_files == []
 
-    def test_time_subset_one_match(self, load_test_data):
+    def test_time_subset_one_match(self, get_files):
         inputs = {"time": "1886-01/1984-11"}
-        sac = SubsetAlignmentChecker(self.test_paths, inputs)
+        sac = SubsetAlignmentChecker(get_files, inputs)
         assert sac.is_aligned is False
         assert sac.aligned_files == []
 
-    def test_time_subset_match(self, load_test_data):
+    def test_time_subset_match(self, get_files):
         inputs = {"time": "1859-12/2005-11"}
         # start defaults to 1st of month
         # end defaults to 30th of month
         # the start and end day of dataset is 16th so this results in a requested time range outside of the actual range
         # so this is aligned.
-        sac = SubsetAlignmentChecker(self.test_paths, inputs)
+        sac = SubsetAlignmentChecker(get_files, inputs)
         assert sac.is_aligned is True
-        assert sac.aligned_files == self.test_paths
+        assert sac.aligned_files == get_files
 
 
 class TestYearMonthDay1200:
@@ -62,35 +67,38 @@ class TestYearMonthDay1200:
     )
     # Actual range in files is: 18500101-20091130
 
-    test_paths = sorted(glob.glob(test_path))
+    @pytest.fixture
+    def get_files(self, load_test_data):
+        test_paths = sorted(glob.glob(self.test_path))
+        return test_paths
 
-    def test_no_subset(self, load_test_data):
+    def test_no_subset(self, get_files):
         inputs = {}
-        sac = SubsetAlignmentChecker(self.test_paths, inputs)
+        sac = SubsetAlignmentChecker(get_files, inputs)
         assert sac.is_aligned is True
-        assert sac.aligned_files == self.test_paths
+        assert sac.aligned_files == get_files
 
-    def test_area_subset(self, load_test_data):
+    def test_area_subset(self, get_files):
         inputs = {"area": "0.,49.,10.,65"}
-        sac = SubsetAlignmentChecker(self.test_paths, inputs)
+        sac = SubsetAlignmentChecker(get_files, inputs)
         assert sac.is_aligned is False
         assert sac.aligned_files == []
 
-    def test_time_subset_no_match(self, load_test_data):
+    def test_time_subset_no_match(self, get_files):
         inputs = {"time": "1886-01-01/1930-11-01"}
-        sac = SubsetAlignmentChecker(self.test_paths, inputs)
+        sac = SubsetAlignmentChecker(get_files, inputs)
         assert sac.is_aligned is False
         assert sac.aligned_files == []
 
-    def test_time_subset_one_match(self, load_test_data):
+    def test_time_subset_one_match(self, get_files):
         inputs = {"time": "1900-01-01/1930-11-01"}
-        sac = SubsetAlignmentChecker(self.test_paths, inputs)
+        sac = SubsetAlignmentChecker(get_files, inputs)
         assert sac.is_aligned is False
         assert sac.aligned_files == []
 
-    def test_time_subset_matches_one_file(self, load_test_data):
+    def test_time_subset_matches_one_file(self, get_files):
         inputs = {"time": "1900-01-01T12:00:00/1909-12-31T12:00:00"}
-        sac = SubsetAlignmentChecker(self.test_paths, inputs)
+        sac = SubsetAlignmentChecker(get_files, inputs)
         assert sac.is_aligned is True
         assert sac.aligned_files == [
             f"{MINI_ESGF_MASTER_DIR}/test_data/gws/nopw/j04/cp4cds1_vol1/data/c3s-cmip5"
@@ -98,7 +106,7 @@ class TestYearMonthDay1200:
             f"/tas_day_EC-EARTH_historical_r1i1p1_19000101-19091231.nc"
         ]
 
-    def test_time_subset_matches_exact_range_excluding_hour(self, load_test_data):
+    def test_time_subset_matches_exact_range_excluding_hour(self, get_files):
         """Tests alignment of full dataset where:
         - Real range: 18500101-20091130
         - Start: 18500101 (exact start)
@@ -108,62 +116,62 @@ class TestYearMonthDay1200:
         for these files is 12:00:00.
         """
         inputs = {"time": "1850-01-01/2009-11-30"}
-        sac = SubsetAlignmentChecker(self.test_paths, inputs)
+        sac = SubsetAlignmentChecker(get_files, inputs)
         assert sac.is_aligned is False
         assert sac.aligned_files == []
 
-    def test_time_subset_matches_before_to_end(self, load_test_data):
+    def test_time_subset_matches_before_to_end(self, get_files):
         """Tests alignment of full dataset where:
         - Real range: 18500101-20091130
         - Start: 17000101 (before)
         - End:   20091130T12:00:00 (exact end)
         """
         inputs = {"time": "1700-01-01/2009-11-30T12:00:00"}
-        sac = SubsetAlignmentChecker(self.test_paths, inputs)
+        sac = SubsetAlignmentChecker(get_files, inputs)
         assert sac.is_aligned is True
-        assert sac.aligned_files == self.test_paths
+        assert sac.aligned_files == get_files
 
-    def test_time_subset_matches_start_to_after(self, load_test_data):
+    def test_time_subset_matches_start_to_after(self, get_files):
         """Tests alignment of full dataset where:
         - Real range: 18500101-20091130
         - Start: 18500101T12:00:00 (exact start)
         - End:   29991230 (after)
         """
         inputs = {"time": "1850-01-01T12:00:00/2999-12-30"}
-        sac = SubsetAlignmentChecker(self.test_paths, inputs)
+        sac = SubsetAlignmentChecker(get_files, inputs)
         assert sac.is_aligned is True
-        assert sac.aligned_files == self.test_paths
+        assert sac.aligned_files == get_files
 
-    def test_time_subset_matches_before_to_after(self, load_test_data):
+    def test_time_subset_matches_before_to_after(self, get_files):
         """Tests alignment of full dataset where:
         - Real range: 18500101-20091130
         - Start: 17000101 (before)
         - End:   29991230 (after)
         """
         inputs = {"time": "1700-01-01/2999-12-30"}
-        sac = SubsetAlignmentChecker(self.test_paths, inputs)
+        sac = SubsetAlignmentChecker(get_files, inputs)
         assert sac.is_aligned is True
-        assert sac.aligned_files == self.test_paths
+        assert sac.aligned_files == get_files
 
-    def test_time_subset_matches_including_hour(self, load_test_data):
+    def test_time_subset_matches_including_hour(self, get_files):
         """Tests alignment of full dataset where:
         - Real range: 1850-01-01T12:00:00 to 2009-11-30T12:00:00
         - Start: 1850-01-01T12:00:00 (exact start)
         - End:   2009-11-30T12:00:00 (exact end)
         """
         inputs = {"time": "1850-01-01T12:00:00/2009-11-30T12:00:00"}
-        sac = SubsetAlignmentChecker(self.test_paths, inputs)
+        sac = SubsetAlignmentChecker(get_files, inputs)
         assert sac.is_aligned is True
-        assert sac.aligned_files == self.test_paths
+        assert sac.aligned_files == get_files
 
-    def test_time_subset_no_match_including_hour(self, load_test_data):
+    def test_time_subset_no_match_including_hour(self, get_files):
         """Tests not aligned when time not aligned with file:
         - Real range: 1850-01-01T12:00:00 to 2009-11-30T12:00:00
         - Start: 1850-01-01T14:00:00 (start)
         - End:   2009-11-30T12:00:00 (exact end)
         """
         inputs = {"time": "1850-01-01T14:00:00/2009-11-30T12:00:00"}
-        sac = SubsetAlignmentChecker(self.test_paths, inputs)
+        sac = SubsetAlignmentChecker(get_files, inputs)
         assert sac.is_aligned is False
         assert sac.aligned_files == []
 
@@ -175,11 +183,15 @@ class TestYearMonthDay0000:
         f"{MINI_ESGF_MASTER_DIR}/test_data/badc/cmip5/data/cmip5/output1/MOHC/HadGEM2-ES/historical/mon/atmos/Amon"
         f"/r1i1p1/latest/tas/*.nc"
     )
-    test_paths = sorted(glob.glob(test_path))
+    
+    @pytest.fixture
+    def get_files(self, load_test_data):
+        test_paths = sorted(glob.glob(self.test_path))
+        return test_paths
 
     # actual range in files is 185912-200511
 
-    def test_time_subset_matches_no_hour(self, load_test_data):
+    def test_time_subset_matches_no_hour(self, get_files):
         """Tests alignment of full dataset where:
         - Real range: 1859-12-16T00:00:00 to 2005-11-16T00:00:00
         - Start: 1859-12-16 (start without hour)
@@ -187,18 +199,18 @@ class TestYearMonthDay0000:
 
         """
         inputs = {"time": "1859-12-16/2005-11-16"}
-        sac = SubsetAlignmentChecker(self.test_paths, inputs)
+        sac = SubsetAlignmentChecker(get_files, inputs)
         # aligns because default is timestamp of 00:00:00 if not provided
         assert sac.is_aligned is True
-        assert sac.aligned_files == self.test_paths
+        assert sac.aligned_files == get_files
 
-    def test_time_subset_matches_including_hour(self, load_test_data):
+    def test_time_subset_matches_including_hour(self, get_files):
         """Tests alignment of full dataset where:
         - Real range: 1859-12-16T00:00:00 to 2005-11-16T00:00:00
         - Start: 1859-12-16T00:00:00 (exact start)
         - End:   2005-11-16T00:00:00 (exact end)
         """
         inputs = {"time": "1859-12-16T00:00:00/2005-11-16T00:00:00"}
-        sac = SubsetAlignmentChecker(self.test_paths, inputs)
+        sac = SubsetAlignmentChecker(get_files, inputs)
         assert sac.is_aligned is True
-        assert sac.aligned_files == self.test_paths
+        assert sac.aligned_files == get_files

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,15 +4,15 @@ import pytest
 from rook.utils.input_utils import resolve_to_file_paths
 from rook.utils.metalink_utils import build_metalink
 
-from .common import TESTS_HOME
+from .common import TESTS_HOME, MINI_ESGF_MASTER_DIR
 
-test_dir = f"{TESTS_HOME}/mini-esgf-data/test_data"
+test_dir = f"{MINI_ESGF_MASTER_DIR}/test_data"
 
 
-def test_build_metalink(tmpdir):
+def test_build_metalink(tmpdir, load_test_data):
     cmip6_nc = os.path.join(
-        TESTS_HOME,
-        "mini-esgf-data/test_data/badc/cmip6/data/CMIP6/CMIP/MPI-M/MPI-ESM1-2-HR/historical/r1i1p1f1/SImon/siconc"
+        test_dir,
+        "badc/cmip6/data/CMIP6/CMIP/MPI-M/MPI-ESM1-2-HR/historical/r1i1p1f1/SImon/siconc"
         "/gn/latest/siconc_SImon_MPI-ESM1-2-HR_historical_r1i1p1f1_gn_185001-185412.nc",
     )  # noqa
     ml4 = build_metalink(
@@ -62,7 +62,7 @@ def test_resolve_to_file_paths_mixed():
         )
 
 
-def test_resolve_to_file_paths_urls():
+def test_resolve_to_file_paths_urls(load_test_data):
     coll = [
         "https://data.mips.copernicus-climate.eu/thredds/fileServer/esg_c3s-cmip6/CMIP/E3SM-Project/E3SM-1-1"
         "/historical/r1i1p1f1/Amon/rlus/gr/v20191211/rlus_Amon_E3SM-1-1_historical_r1i1p1f1_gr_200001-200912.nc",


### PR DESCRIPTION
## Overview

Removed `mini-esgf-data` submodule in favour of cloning it it when needed for tests. This is done using a new pytest fixture `load_test_data` which implements the `GitPython` library (now added to `requirements_dev.txt`)


