### PR TITLE
Release 0.3.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Changes
 Unreleased
 ==========
 
+0.3.1 (2021-02-24)
+==================
+
+* Pin ``cf_xarray <0.5.0`` ... does not work with daops/clisops.
+
 0.3.0 (2021-02-24)
 ==================
 

--- a/environment.yml
+++ b/environment.yml
@@ -16,6 +16,7 @@ dependencies:
 - cftime>=1.2.1
 - udunits2>=2.2
 - xarray>=0.16
+- cf_xarray>=0.4.0,<0.5.0
 - dask>=2.26
 - netcdf4>=1.4
 - daops>=0.4.0,<0.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,8 @@ jinja2
 click
 psutil
 networkx
-xarray>=0.15
+xarray>=0.16
+cf-xarray>=0.4.0,<0.5.0
 dask[complete]
 netcdf4
 python-dateutil>=2.8.1


### PR DESCRIPTION
## Overview

This PR updates the requirements and changes for release 0.3.1.

We need to pin `cf_xarray <0.5.0` ... it does not work with `daops/clisops`.

## Related Issue / Discussion

## Additional Information

Links to other issues or sources.
