### PR TITLE
Change default behaviour for apply fixes for average

### DIFF
--- a/rook/processes/wps_average.py
+++ b/rook/processes/wps_average.py
@@ -50,7 +50,7 @@ class Average(Process):
                 "Apply Fixes",
                 data_type="boolean",
                 abstract="Apply fixes to datasets.",
-                default="1",
+                default="0",
                 min_occurs=1,
                 max_occurs=1,
             ),


### PR DESCRIPTION
## Overview

Elasticsearch was down on Tuesday and the average tests were failing. It made me realise we had the default for average as `apply_fixes=True`. I've changed it to `apply_fixes=False` to be consistent with subset.