### PR TITLE
Update smoke

### DIFF
--- a/rook/director/director.py
+++ b/rook/director/director.py
@@ -82,6 +82,10 @@ class Director:
         if self.inputs.get("apply_fixes") and self.requires_fixes():
             return
 
+        # TODO: quick fix for average. Don't use original files for average operator
+        if "dims" in self.inputs:
+            return
+
         # Finally, check if the subset requirements can align with whole datasets
         if self.request_aligns_with_files():
             # This call sets values for self.original_file_urls AND self.use_original_files

--- a/tests/smoke/test_smoke_checks.py
+++ b/tests/smoke/test_smoke_checks.py
@@ -17,15 +17,15 @@ CMIP5_COLLECTION = (
     "c3s-cmip5.output1.ICHEC.EC-EARTH.historical.day.atmos.day.r1i1p1.tas.latest"
 )
 
-WF_SUBSET_AVERAGE_CMIP5 = json.dumps(
+WF_SUBSET_AVERAGE = json.dumps(
     {
-        "doc": "subset+average on cmip5 tas",
-        "inputs": {"ds": [CMIP5_COLLECTION]},
+        "doc": "subset+average on cmip6 rlds",
+        "inputs": {"ds": [CMIP6_COLLECTION]},
         "outputs": {"output": "average_ds/output"},
         "steps": {
             "subset_ds": {
                 "run": "subset",
-                "in": {"collection": "inputs/ds", "time": "1900-01-01/1900-12-31"},
+                "in": {"collection": "inputs/ds", "time": "2020-01-01/2020-12-31"},
             },
             "average_ds": {
                 "run": "average",
@@ -94,14 +94,14 @@ def test_smoke_execute_subset_time_and_area_cross_meridian(wps):
 
 
 def test_smoke_execute_average_time(wps):
-    inputs = [("collection", CMIP5_COLLECTION), ("dims", "time")]
+    inputs = [("collection", CMIP6_COLLECTION), ("dims", "time")]
     url = wps.execute("average", inputs)
-    assert "tas_day_EC-EARTH_historical_r1i1p1_avg-t.nc" in url
+    assert "rlds_Amon_INM-CM5-0_ssp245_r1i1p1f1_gr1_avg-t.nc" in url
 
 
 def test_smoke_execute_orchestrate(wps):
     inputs = [
-        ("workflow", ComplexDataInput(WF_SUBSET_AVERAGE_CMIP5)),
+        ("workflow", ComplexDataInput(WF_SUBSET_AVERAGE)),
     ]
     url = wps.execute("orchestrate", inputs)
-    assert "tas_day_EC-EARTH_historical_r1i1p1_avg-t.nc" in url
+    assert "rlds_Amon_INM-CM5-0_ssp245_r1i1p1f1_gr1_avg-t.nc" in url


### PR DESCRIPTION
## Overview

This PR updates the smoke tests:

Changes:

* Use average with CMIP6, monthly testdata
* Quick fix : don't use original files when using average operator

## Related Issue / Discussion

## Additional Information
