### PR TITLE
remove original files option for average and add test for average on …

### DIFF
--- a/rook/processes/wps_average.py
+++ b/rook/processes/wps_average.py
@@ -54,15 +54,6 @@ class Average(Process):
                 min_occurs=1,
                 max_occurs=1,
             ),
-            LiteralInput(
-                "original_files",
-                "Original Files",
-                data_type="boolean",
-                abstract="Return original files only.",
-                default="0",
-                min_occurs=1,
-                max_occurs=1,
-            ),
         ]
         outputs = [
             ComplexOutput(
@@ -124,9 +115,6 @@ class Average(Process):
             ),
             "pre_checked": parse_wps_input(
                 request.inputs, "pre_checked", default=False
-            ),
-            "original_files": parse_wps_input(
-                request.inputs, "original_files", default=False
             ),
             "dims": parse_wps_input(request.inputs, "dims", default=None),
         }

--- a/tests/test_wps_average.py
+++ b/tests/test_wps_average.py
@@ -30,3 +30,17 @@ def test_wps_average_time_lat():
     )
     assert_response_success(resp)
     assert "output" in get_output(resp.xml)
+
+
+def test_wps_average_c3s_cmip6():
+    # test the case where the inventory is used
+    client = client_for(Service(processes=[Average()]))
+    datainputs = "collection=c3s-cmip6.ScenarioMIP.INM.INM-CM5-0.ssp245.r1i1p1f1.Amon.rlds.gr1.v20190619"
+    datainputs += ";dims=time,latitude"
+    resp = client.get(
+        "?service=WPS&request=Execute&version=1.0.0&identifier=average&datainputs={}".format(
+            datainputs
+        )
+    )
+    assert_response_success(resp)
+    assert "output" in get_output(resp.xml)


### PR DESCRIPTION
…c3s-cmip6 data

## Overview

Removed original files option for average - it doesn't make sense here. Added a test for average on `c3s-cmip6` data where the inventory is used.

## Related Issue / Discussion

#135 

@cehbrecht does the `min_occurs=1` on dims mean that this is a required argument?