### PR TITLE
Fix smoke: output via reference

### DIFF
--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -1,5 +1,7 @@
 import pytest
 
+import requests
+
 from owslib.wps import WebProcessingService, monitorExecution
 from pywps import configuration as config
 
@@ -25,11 +27,13 @@ class RookWPS:
         return self.wps.describeprocess(identifier)
 
     def execute(self, identifier, inputs):
-        outputs = [("output", False, None)]
+        outputs = [("output", True, None)]
         execution = self.wps.execute(identifier, inputs, output=outputs)
         monitorExecution(execution)
         assert execution.isSucceded() is True
-        xml = execution.processOutputs[0].data[0]
+        assert len(execution.processOutputs) > 0
+        ml_url = execution.processOutputs[0].reference
+        xml = requests.get(ml_url).text
         url = parse_metalink(xml)
         return url
 


### PR DESCRIPTION
## Overview

This PR is a workaround for an issue with pywps when using scheduler backend. Outputs were given always by reference, though it was requested to be included in the response document.

Now, we always retrieve in smoke the `output` via reference.

## Related Issue / Discussion

## Additional Information
