### PR TITLE
Updates for locust tests

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -14,5 +14,6 @@ cruft
 black
 pre-commit
 GitPython>=3.1.12
+pyquery
 locust
 jinja2

--- a/tests/storm/locustfile.py
+++ b/tests/storm/locustfile.py
@@ -31,7 +31,7 @@ WF_SUBSET_AVERAGE = json.dumps(
 
 
 class RookUser(HttpUser):
-    host = "http://localhost:5000/wps"
+    host = "http://localhost:5000"
     wait_time = between(1, 10)
 
     @task(1)


### PR DESCRIPTION
## Overview

This PR fixes a dependency installation and modifies the default host URL for the Locust swarm tests.

Changes:

* Added package to test dependencies: `pyquery`
* Change default locust host to remove `/wps` in URL, as it is not needed.

## Related Issue / Discussion

Relates to: https://github.com/roocs/34e-mngmt/issues/91

