### PR TITLE
fix tests, using latest pywps

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -23,5 +23,5 @@ dependencies:
 # provenance
 - prov>=2.0.0
 - graphviz
-- pip:
-  - pywps @ git+https://github.com/geopython/pywps.git@pywps-4.4#egg=pywps
+#- pip:
+#  - pywps @ git+https://github.com/geopython/pywps.git@pywps-4.4#egg=pywps

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
 - pip
 - python=3.7 # >=3.6,<3.8
-- pywps>=4.4.0,<4.5
+# - pywps>=4.4.0,<4.5
 - jinja2
 - click
 - psutil
@@ -23,5 +23,5 @@ dependencies:
 # provenance
 - prov>=2.0.0
 - graphviz
-#- pip:
-#    - daops @ git+https://github.com/roocs/daops.git@master#egg=daops
+- pip:
+  - pywps @ git+https://github.com/geopython/pywps.git@pywps-4.4#egg=pywps

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-pywps>=4.4.0,<4.5
+# pywps>=4.4.0,<4.5
+pywps @ git+https://github.com/geopython/pywps.git@pywps-4.4#egg=pywps
 jinja2
 click
 psutil

--- a/rook/default.cfg
+++ b/rook/default.cfg
@@ -1,7 +1,7 @@
 [metadata:main]
 identification_title = rook
-identification_abstract = A WPS service for roocs.
-identification_keywords = PyWPS, WPS, OGC, processing, birdhouse, roocs, demo, cp4cds, copernicus, ecmwf
+identification_abstract = Rook is a Web Processing Service (WPS) of the roocs project to allow remote operations like subsetting on climate model data.
+identification_keywords = PyWPS, WPS, OGC, processing, birdhouse, roocs, copernicus
 identification_keywords_type = theme
 provider_name = rook
 provider_url=http://rook.readthedocs.org/en/latest/
@@ -10,7 +10,6 @@ provider_url=http://rook.readthedocs.org/en/latest/
 url = http://localhost:5000/wps
 outputurl = http://localhost:5000/outputs
 allowedinputpaths = /
-maxsingleinputsize = 10gb
 maxprocesses = 10
 parallelprocesses = 2
 

--- a/rook/utils/metalink_utils.py
+++ b/rook/utils/metalink_utils.py
@@ -16,6 +16,8 @@ def build_metalink(identity, description, workdir, file_uris, file_type="NetCDF"
 
         if urlparse(file_uri).scheme in ["http", "https"]:
             mf.url = file_uri
+            # TODO: size calculation takes too long. Set size from inventory/catalog.
+            mf.size = 0
         else:
             mf.file = file_uri
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,19 +23,19 @@ search = "version": "{current_version}",
 replace = "version": "{new_version}",
 
 [tool:pytest]
-addopts = 
+addopts =
 	--strict
 	--tb=native
 	tests/
 python_files = test_*.py
-markers = 
+markers =
 	online: mark test to need internet connection
 	slow: mark test to be slow
 	smoke: mark test as a smoke/sanity test
 
 [flake8]
 max-line-length = 120
-exclude = 
+exclude =
 	.git,
 	__pycache__,
 	docs/source/conf.py,
@@ -43,7 +43,7 @@ exclude =
 	dist,
 	src,
 	mini-esgf-data,
-ignore = 
+ignore =
 	F401
 	E402
 	W503

--- a/tests/test_director/test_director.py
+++ b/tests/test_director/test_director.py
@@ -14,11 +14,10 @@ from rook.director import Director
 #           }
 
 
-@pytest.mark.skip(reason="need a new test dataset")
 class TestDirectorCMIP6:
 
     collection = [
-        "c3s-cmip6.CMIP.IPSL.IPSL-CM6A-LR.historical.r1i1p1f1.Amon.rlds.gr.v20180803"
+        "c3s-cmip6.ScenarioMIP.INM.INM-CM5-0.ssp245.r1i1p1f1.Amon.rlds.gr1.v20190619"
     ]
 
     def test_project(self):
@@ -33,9 +32,9 @@ class TestDirectorCMIP6:
         assert d.use_original_files is True
         assert list(d.original_file_urls.items())[0][1] == [
             "https://data.mips.copernicus-climate.eu/thredds/fileServer"
-            "/esg_c3s-cmip6/CMIP/IPSL/IPSL-CM6A-LR/historical"
-            "/r1i1p1f1/Amon/rlds/gr/v20180803/rlds_Amon_"
-            "IPSL-CM6A-LR_historical_r1i1p1f1_gr_185001-201412.nc"
+            "/esg_c3s-cmip6"
+            "/ScenarioMIP/INM/INM-CM5-0/ssp245/r1i1p1f1/Amon/rlds/gr1/v20190619"
+            "/rlds_Amon_INM-CM5-0_ssp245_r1i1p1f1_gr1_201501-210012.nc"
         ]
 
     def test_pre_checked_not_characterised(self):
@@ -64,14 +63,14 @@ class TestDirectorCMIP6:
 
     def test_time_subset_aligned(self):
         # original files
-        inputs = {"time": "1850-01-01/2014-12-31"}
+        inputs = {"time": "2015-01-01/2100-12-31"}
         d = Director(self.collection, inputs)
         assert d.use_original_files is True
         assert list(d.original_file_urls.items())[0][1] == [
             "https://data.mips.copernicus-climate.eu/thredds/fileServer"
-            "/esg_c3s-cmip6/CMIP/IPSL/IPSL-CM6A-LR/historical"
-            "/r1i1p1f1/Amon/rlds/gr/v20180803/rlds_Amon_"
-            "IPSL-CM6A-LR_historical_r1i1p1f1_gr_185001-201412.nc"
+            "/esg_c3s-cmip6"
+            "/ScenarioMIP/INM/INM-CM5-0/ssp245/r1i1p1f1/Amon/rlds/gr1/v20190619"
+            "/rlds_Amon_INM-CM5-0_ssp245_r1i1p1f1_gr1_201501-210012.nc"
         ]
 
     def test_only_time_no_match(self):

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -81,12 +81,13 @@ def test_run_tree_wf_6():
     assert "zostoga_mon_inmcm4_rcp45_r1i1p1_20850116-21001216.nc" in output[0]
 
 
-@pytest.mark.skip(reason="needs patched pywps version 4.4.1")
-def test_run_wf_collection_only():
-    wfdoc = resource_file("wf_cmip6_subset_collection_only.json")
+def test_wf_c3s_cmip6_collection_only():
+    wfdoc = resource_file("wf_c3s_cmip6_subset_collection_only.json")
     wf = workflow.WorkflowRunner(output_dir=tempfile.mkdtemp())
     output = wf.run(wfdoc)
-    assert (
-        "rlds_Amon_IPSL-CM6A-LR_historical_r1i1p1f1_gr_18500116-20141216.nc"
-        in output[0]
+    expected_url = (
+        "https://data.mips.copernicus-climate.eu/thredds/fileServer/esg_c3s-cmip6/"
+        "CMIP/SNU/SAM0-UNICON/historical/r1i1p1f1/day/pr/gn/v20190323/"
+        "pr_day_SAM0-UNICON_historical_r1i1p1f1_gn_18500101-18501231.nc"
     )
+    assert output[0] == expected_url

--- a/tests/test_wps_orchestrate.py
+++ b/tests/test_wps_orchestrate.py
@@ -1,3 +1,5 @@
+import pytest
+
 import prov
 
 from pywps import Service
@@ -23,9 +25,10 @@ def test_wps_orchestrate():
 
 
 def test_wps_orchestrate_subset_collection_only():
+    # TODO: this test is slow (25secs) ... but should be fast (1sec)
     client = client_for(Service(processes=[Orchestrate()], cfgfiles=[PYWPS_CFG]))
     datainputs = "workflow=@xlink:href=file://{}".format(
-        resource_file("wf_cmip6_subset_collection_only.json")
+        resource_file("wf_c3s_cmip6_subset_collection_only.json")
     )
     resp = client.get(
         "?service=WPS&request=Execute&version=1.0.0&identifier=orchestrate&datainputs={}".format(

--- a/tests/test_wps_subset.py
+++ b/tests/test_wps_subset.py
@@ -1,3 +1,5 @@
+import pytest
+
 import prov
 
 from pywps import Service
@@ -7,7 +9,10 @@ from rook.processes.wps_subset import Subset
 
 from .common import PYWPS_CFG, get_output
 
-import pytest
+
+C3S_CMIP6_MON_COLLECTION = (
+    "c3s-cmip6.ScenarioMIP.INM.INM-CM5-0.ssp245.r1i1p1f1.Amon.rlds.gr1.v20190619"
+)
 
 
 def test_wps_subset_cmip6_no_inv():
@@ -20,7 +25,7 @@ def test_wps_subset_cmip6_no_inv():
         )
     )
     # assert resp.status_code == 200
-    # print(resp.data)
+    print(resp.data)
     # assert_response_success(resp)
     assert (
         "Process error: Some or all of the requested collection are not in the list of available data"
@@ -28,10 +33,10 @@ def test_wps_subset_cmip6_no_inv():
     )
 
 
-def test_wps_subset_cmip6():
+def test_wps_subset_c3s_cmip6():
     client = client_for(Service(processes=[Subset()], cfgfiles=[PYWPS_CFG]))
-    datainputs = "collection=CMIP6.CMIP.IPSL.IPSL-CM6A-LR.historical.r1i1p1f1.Amon.rlds.gr.v20180803"
-    datainputs += ";time=1860-01-01/1900-12-30;area=1,1,300,89"
+    datainputs = f"collection={C3S_CMIP6_MON_COLLECTION}"
+    datainputs += ";time=2015-01-01/2015-12-30;area=1,1,300,89"
     resp = client.get(
         "?service=WPS&request=Execute&version=1.0.0&identifier=subset&datainputs={}".format(
             datainputs
@@ -101,9 +106,9 @@ def test_wps_subset_cmip6_original_files():
     assert "meta4" in get_output(resp.xml)["output"]
 
 
-def test_wps_subset_cmip6_collection_only():
+def test_wps_subset_c3s_cmip6_collection_only():
     client = client_for(Service(processes=[Subset()], cfgfiles=[PYWPS_CFG]))
-    datainputs = "collection=CMIP6.CMIP.IPSL.IPSL-CM6A-LR.historical.r1i1p1f1.Amon.rlds.gr.v20180803"
+    datainputs = f"collection={C3S_CMIP6_MON_COLLECTION}"
     resp = client.get(
         "?service=WPS&request=Execute&version=1.0.0&identifier=subset&datainputs={}".format(
             datainputs

--- a/tests/testdata/wf_c3s_cmip6_subset_collection_only.json
+++ b/tests/testdata/wf_c3s_cmip6_subset_collection_only.json
@@ -1,0 +1,17 @@
+{
+      "doc": "subset collection only",
+      "inputs": {
+          "rlds": ["c3s-cmip6.CMIP.SNU.SAM0-UNICON.historical.r1i1p1f1.day.pr.gn.v20190323"]
+      },
+      "outputs": {
+          "output": "subset_rlds/output"
+      },
+      "steps": {
+          "subset_rlds": {
+              "run": "subset",
+              "in": {
+                  "collection": "inputs/rlds",
+              }
+          },
+      }
+  }


### PR DESCRIPTION
## Overview

This PR fixes the test suite

Changes:

* Using latest pywps with a fix metalink: https://github.com/geopython/pywps/pull/581
* Updated director tests with a new test dataset
* Updated pywps `default.cfg` description ... removed unnecessary `maxsingleinputsize` parameter
* Updated tests to use `c3s-cmip6` datasets

The metalink document skips file size calculation for URLs. URLs are set for "original" files from `https://data.mips.copernicus-climate.eu`. File size calculation takes too long when many files are added (>100).

TODO: we need to have file size in our inventory/catalog, so we can set it without retrieving it via `get` requests.

## Related Issue / Discussion

## Additional Information


