### PR TITLE
Changes for release

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,8 @@
 Changes
 *******
 
-Unreleased
-==========
+0.6.0 (2021-05-20)
+==================
 
 * Inventory urls removed from ``etc/roocs.ini``. Intake catalog url now lives in daops. (#175)
 * Intake catalog base and search functionality moved to daops. Database intake implementation remains in rook. (#175)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,13 @@ Changes
 Unreleased
 ==========
 
-* Inventory urls removed from ``etc/roocs.ini``. Intake catalog url now lives in daops.
-* Intake catalog base and search functionality moved to daops. Database intake implementation remains in rook.
+* Inventory urls removed from ``etc/roocs.ini``. Intake catalog url now lives in daops. (#175)
+* Intake catalog base and search functionality moved to daops. Database intake implementation remains in rook. (#175)
+* Updated to roocs-utils 0.4.0.
+* Updated to clisops 0.6.4.
+* Updated to daops 0.6.0.
+* Added initial usage process (#178)
+
 
 0.5.0 (2021-04-01)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ Unreleased
 
 * Inventory urls removed from ``etc/roocs.ini``. Intake catalog url now lives in daops. (#175)
 * Intake catalog base and search functionality moved to daops. Database intake implementation remains in rook. (#175)
-* Updated to roocs-utils 0.4.0.
+* Updated to roocs-utils 0.4.2.
 * Updated to clisops 0.6.4.
 * Updated to daops 0.6.0.
 * Added initial usage process (#178)

--- a/environment-docs.yml
+++ b/environment-docs.yml
@@ -6,4 +6,4 @@ channels:
 dependencies:
 - python=3.7
 - pywps>=4.2
-- sphinx
+- sphinx<=3.5.4

--- a/environment.yml
+++ b/environment.yml
@@ -17,7 +17,7 @@ dependencies:
 - netcdf4>=1.4
 - daops>=0.6.0,<0.7
 - clisops>=0.6.4,<0.7
-- roocs-utils>=0.4.0,<0.5
+- roocs-utils>=0.4.2,<0.5
 # workflow
 - networkx
 # provenance

--- a/environment.yml
+++ b/environment.yml
@@ -15,9 +15,9 @@ dependencies:
 - xarray>=0.16
 - dask>=2.26
 - netcdf4>=1.4
-- daops>=0.5.0,<0.6
-- clisops>=0.6.3,<0.7
-- roocs-utils>=0.3.0,<0.4
+- daops>=0.6.0,<0.7
+- clisops>=0.6.4,<0.7
+- roocs-utils>=0.4.0,<0.5
 # workflow
 - networkx
 # provenance

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,12 +3,12 @@ jinja2
 click
 psutil
 # daops
-# daops>=0.5.0
-daops @ git+https://github.com/roocs/daops.git@master#egg=daops
-#clisops>=0.6.3
-clisops @ git+https://github.com/roocs/clisops.git
-# roocs-utils>=0.3.0
-roocs-utils @ git+https://github.com/roocs/roocs-utils.git@master#egg=roocs-utils
+daops>=0.6.0
+# daops @ git+https://github.com/roocs/daops.git@master#egg=daops
+clisops>=0.6.4
+# clisops @ git+https://github.com/roocs/clisops.git
+roocs-utils>=0.4.0
+# roocs-utils @ git+https://github.com/roocs/roocs-utils.git@master#egg=roocs-utils
 xarray>=0.16
 dask[complete]
 netcdf4

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ daops>=0.6.0
 # daops @ git+https://github.com/roocs/daops.git@master#egg=daops
 clisops>=0.6.4
 # clisops @ git+https://github.com/roocs/clisops.git
-roocs-utils>=0.4.0
+roocs-utils>=0.4.2
 # roocs-utils @ git+https://github.com/roocs/roocs-utils.git@master#egg=roocs-utils
 xarray>=0.16
 dask[complete]

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,7 +6,7 @@ pytest-notebook
 nbsphinx
 nbval>=0.9.6
 nbconvert
-sphinx>=1.7
+sphinx>=1.7,<=3.5.4
 bumpversion
 twine
 cruft

--- a/rook/catalog/db.py
+++ b/rook/catalog/db.py
@@ -38,18 +38,18 @@ class DBCatalog(Catalog):
     def to_db(self):
         df = self.intake_catalog.load()
         # workaround for NaN values when no time axis (fx datasets)
-        sdf = df.fillna({"start_time": MIN_DATETIME, "end_time": MAX_DATETIME})
+        df = df.fillna({"start_time": MIN_DATETIME, "end_time": MAX_DATETIME})
 
-        # needed when catalog created from catalog_maker instead of above
-        # sdf = df.replace({"start_time": {"undefined": MIN_DATETIME}})
-        # sdf = df.replace({"end_time": {"undefined": MAX_DATETIME}})
+        # needed when catalog created from catalog_maker instead of above - can remove the above eventually
+        df = df.replace({"start_time": {"undefined": MIN_DATETIME}})
+        df = df.replace({"end_time": {"undefined": MAX_DATETIME}})
 
-        sdf = sdf.set_index("ds_id")
+        df = df.set_index("ds_id")
 
         # db connection
         session = get_session()
         try:
-            sdf.to_sql(
+            df.to_sql(
                 self.table_name,
                 session.connection(),
                 if_exists="replace",


### PR DESCRIPTION
## Overview

This PR updates the versions of `roocs-utils`, `clisops` and `daops`
After this rook can be released to allow the next intake catalogue to be used.

Changes:

* Also added in a section to `db.py` to make compatible with next catalogue which uses "undefined" for `start_time` and `end_time` when there is no time dimension.

* Restricted the sphinx version to 3.5.4 as latest version raises an error, as mentioned here https://github.com/geopython/pywps/issues/608
