### PR TITLE
renamed dctermns to dct

### DIFF
--- a/rook/provenance.py
+++ b/rook/provenance.py
@@ -20,7 +20,7 @@ PROVONE_DATA = PROVONE["Data"]
 PROVONE_EXECUTION = PROVONE["Execution"]
 
 # dcterms namespace
-DCTERMS = Namespace("dcterms", uri="http://purl.org/dc/terms/")
+DCTERMS = Namespace("dct", uri="http://purl.org/dc/terms/")
 DCTERMS_SOURCE = DCTERMS["source"]
 
 # roocs namespace


### PR DESCRIPTION
## Overview

This PR updates the provenance to climate4impact terminology.

Changes:

* Renamed namespace `dcterms` to `dct`.

## Related Issue / Discussion

## Additional Information


