### PR TITLE
Switch on apply fixes

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -16,8 +16,8 @@ dependencies:
 - dask>=2.26
 - netcdf4>=1.4
 - bottleneck>=1.3.1,<1.4
-- daops>=0.7.0,<0.8
-- clisops>=0.7.0,<0.8
+#- daops>=0.7.0,<0.8
+- clisops>=0.7.0,<0.9
 - roocs-utils>=0.5.0,<0.6
 # workflow
 - networkx

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ click
 psutil
 # daops
 daops>=0.7.0,<0.8
-clisops>=0.7.0,<0.8
+clisops>=0.7.0,<0.9
 roocs-utils>=0.5.0,<0.6
 xarray>=0.16
 dask[complete]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ click
 psutil
 # daops
 # daops>=0.7.0,<0.8
-git+https://github.com/roocs/daops@master#egg=daops
+daops @ git+https://github.com/roocs/daops@master#egg=daops
 clisops>=0.7.0,<0.9
 roocs-utils>=0.5.0,<0.6
 xarray>=0.16

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ click
 psutil
 # daops
 # daops>=0.7.0,<0.8
-git+https://github.com/roocs/daops.git
+git+https://github.com/roocs/daops@master#egg=daops
 clisops>=0.7.0,<0.9
 roocs-utils>=0.5.0,<0.6
 xarray>=0.16

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,8 @@ jinja2
 click
 psutil
 # daops
-daops>=0.7.0,<0.8
+# daops>=0.7.0,<0.8
+git+https://github.com/roocs/daops.git
 clisops>=0.7.0,<0.9
 roocs-utils>=0.5.0,<0.6
 xarray>=0.16

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -14,3 +14,4 @@ cruft
 black
 pre-commit
 GitPython>=3.1.12
+beautifulsoup4

--- a/rook/director/director.py
+++ b/rook/director/director.py
@@ -78,6 +78,7 @@ class Director:
         if self.inputs.get("original_files"):
             self.original_file_urls = self.search_result.download_urls()
             self.use_original_files = True
+            self.inputs["apply_fixes"] = False
             return
 
         # Raise exception if "pre_checked" selected but data has not been characterised by dachar
@@ -88,6 +89,9 @@ class Director:
 
         # Check if fixes are required. If so, then return (and subset will be generated).
         if self.inputs.get("apply_fixes") and self.requires_fixes():
+            return
+        else:
+            self.inputs["apply_fixes"] = False
             return
 
         # TODO: quick fix for average. Don't use original files for average operator

--- a/rook/director/director.py
+++ b/rook/director/director.py
@@ -48,7 +48,7 @@ class Director:
         self._check_apply_fixes()
 
     def _check_apply_fixes(self):
-        if self.inputs.get("apply_fixes") and not self.inputs.get("original_files") and self.requires_fixes():
+        if self.inputs.get("apply_fixes") and not self.use_original_files and self.requires_fixes():
             self.inputs["apply_fixes"] = True
         else:
             self.inputs["apply_fixes"] = False

--- a/rook/operator.py
+++ b/rook/operator.py
@@ -32,6 +32,7 @@ class Operator(object):
         if is_file_list(collection):
             # This block is called if this is NOT the first stage of a workflow, and
             # the collection will be a file list (one or more files)
+            args["apply_fixes"] = False
             kwargs = deepcopy(args)
             file_paths = resolve_to_file_paths(args.get("collection"))
             kwargs["collection"] = FileMapper(file_paths)

--- a/rook/processes/wps_average.py
+++ b/rook/processes/wps_average.py
@@ -49,7 +49,7 @@ class Average(Process):
                 "Apply Fixes",
                 data_type="boolean",
                 abstract="Apply fixes to datasets.",
-                default="0",
+                default="1",
                 min_occurs=1,
                 max_occurs=1,
             ),

--- a/rook/processes/wps_subset.py
+++ b/rook/processes/wps_subset.py
@@ -144,7 +144,7 @@ class Subset(Process):
             "collection": collection,
             "output_dir": self.workdir,
             "apply_fixes": parse_wps_input(
-                request.inputs, "apply_fixes", default=False
+                request.inputs, "apply_fixes", default=True
             ),
             "pre_checked": parse_wps_input(
                 request.inputs, "pre_checked", default=False

--- a/rook/processes/wps_subset.py
+++ b/rook/processes/wps_subset.py
@@ -80,7 +80,7 @@ class Subset(Process):
                 "Apply Fixes",
                 data_type="boolean",
                 abstract="Apply fixes to datasets.",
-                default="0",
+                default="1",
                 min_occurs=1,
                 max_occurs=1,
             ),

--- a/rook/workflow.py
+++ b/rook/workflow.py
@@ -35,7 +35,7 @@ def replace_inputs(wfdoc):
         # fixes are only applied to start steps
         if step_id in start_steps:
             steps[step_id]["in"]["apply_fixes"] = steps[step_id]["in"].get(
-                "apply_fixes", False
+                "apply_fixes", True
             )
         else:
             steps[step_id]["in"]["apply_fixes"] = False

--- a/tests/common.py
+++ b/tests/common.py
@@ -42,9 +42,19 @@ def write_roocs_cfg():
 
     [project:c3s-cmip6]
     base_dir = {{ base_dir }}/test_data/badc/cmip6/data/CMIP6
+    # use_catalog = False
 
     [project:c3s-cordex]
     base_dir = {{ base_dir }}/test_data/gws/nopw/j04/cp4cds1_vol1/data/c3s-cordex
+
+    [dachar:store]
+    store_type = elasticsearch
+
+    [elasticsearch]
+    endpoint = elasticsearch.ceda.ac.uk
+    port = 443
+    fix_store = c3s-roocs-fix
+    fix_proposal_store = c3s-roocs-fix-prop
     """
     cfg = Template(cfg_templ).render(base_dir=MINI_ESGF_MASTER_DIR)
     with open(ROOCS_CFG, "w") as fp:

--- a/tests/test_wps_cmip6_decadal.py
+++ b/tests/test_wps_cmip6_decadal.py
@@ -1,0 +1,44 @@
+import pytest
+
+import xarray as xr
+from bs4 import BeautifulSoup
+
+from pywps import Service
+from pywps.tests import assert_process_exception, assert_response_success, client_for
+
+from rook.processes.wps_subset import Subset
+
+from .common import PYWPS_CFG, get_output
+
+
+def extract_paths_from_metalink(path):
+    path = path.replace("file://", "")
+    doc = BeautifulSoup(open(path, "r").read(), "xml")
+    paths = [el.text.replace("file://", "") for el in doc.find_all("metaurl")]
+    return paths
+
+
+def assert_decadal_fix_applied(path):
+    assert "meta4" in path
+    paths = extract_paths_from_metalink(path)
+    assert len(paths) > 0
+    ds = xr.open_dataset(paths[0])
+    assert "reftime" in ds.coords
+    assert "leadtime" in ds.coords
+    assert ds.leadtime.long_name == "Time elapsed since the start of the forecast"
+    assert ds.leadtime.standard_name == "forecast_period"
+
+
+@pytest.mark.xfail(reason="c3s-cmip6 decdal not in catalog")
+def test_wps_subset_c3s_cmip6_decadal():
+    client = client_for(Service(processes=[Subset()], cfgfiles=[PYWPS_CFG]))
+    collection = "c3s-cmip6.DCPP.MOHC.HadGEM3-GC31-MM.dcppA-hindcast.s2004-r3i1p1f2.Amon.pr.gn.v20200417"
+    datainputs = f"collection={collection}"
+    # datainputs += ";time=1960-01-01/1961-01-01"
+    resp = client.get(
+        "?service=WPS&request=Execute&version=1.0.0&identifier=subset&datainputs={}".format(
+            datainputs
+        )
+    )
+    assert_response_success(resp)
+    assert_decadal_fix_applied(path=get_output(resp.xml)["output"])


### PR DESCRIPTION
## Overview

 Changes:

* Added test for cmip6 decadal.
* Use fixes by default.
* Uses `check_apply_fixes()` to check if a fix is available and will be applied. 
  * Updates `apply_fixes` parameter accordingly and this will be documented in the provenance.

The cmip6 decadal is `xfailed` because the cmip6 decdal is not in the c3s-cmip6 catalog. Need disable the catalog check in `roocs.ini` to run the test:
```
[project:c3s-cmip6]
use_catalog = False
```

## Related Issue / Discussion

Fix #201 

## Additional Information


