### PR TITLE
renamed average_dim operator to average

### DIFF
--- a/rook/operator.py
+++ b/rook/operator.py
@@ -74,7 +74,7 @@ class AverageByTime(Operator):
 
 
 class AverageByDimension(Operator):
-    prefix = "average_dim"
+    prefix = "average"
 
     def _get_runner(self):
         return run_average_by_dim

--- a/rook/processes/wps_average_dim.py
+++ b/rook/processes/wps_average_dim.py
@@ -83,7 +83,7 @@ class AverageByDimension(Process):
 
         super(AverageByDimension, self).__init__(
             self._handler,
-            identifier="average_dim",
+            identifier="average",
             title="Average by Dimensions",
             abstract="Run averaging by dimensions on climate model data.",
             metadata=[
@@ -128,7 +128,5 @@ class AverageByDimension(Process):
             director.output_uris,
         )
 
-        populate_response(
-            response, "average_dim", self.workdir, inputs, collection, ml4
-        )
+        populate_response(response, "average", self.workdir, inputs, collection, ml4)
         return response

--- a/rook/workflow.py
+++ b/rook/workflow.py
@@ -142,7 +142,7 @@ class Workflow(BaseWorkflow):
             collection = step["in"]["collection"]
             result = self.average_time_op.call(step["in"])
             self.prov.add_operator(step_id, step["in"], collection, result)
-        elif "average_dim" == step["run"]:
+        elif "average" == step["run"]:
             collection = step["in"]["collection"]
             result = self.average_dim_op.call(step["in"])
             self.prov.add_operator(step_id, step["in"], collection, result)

--- a/tests/smoke/test_smoke_checks.py
+++ b/tests/smoke/test_smoke_checks.py
@@ -32,7 +32,7 @@ WF_SUBSET_AVERAGE = json.dumps(
                 "in": {"collection": "inputs/ds", "time": "2020-01-01/2020-12-31"},
             },
             "average_ds": {
-                "run": "average_dim",
+                "run": "average",
                 "in": {"collection": "subset_ds/output", "dims": "time"},
             },
         },
@@ -45,7 +45,7 @@ def test_smoke_get_capabilities(wps):
     assert caps.identification.type == "WPS"
     processes = [p.identifier for p in caps.processes]
     assert "subset" in processes
-    assert "average_dim" in processes
+    assert "average" in processes
     assert "average_time" in processes
     assert "orchestrate" in processes
 
@@ -60,8 +60,8 @@ def test_smoke_describe_process_subset(wps):
 
 
 def test_smoke_describe_process_average_dim(wps):
-    process = wps.describeprocess("average_dim")
-    assert process.identifier == "average_dim"
+    process = wps.describeprocess("average")
+    assert process.identifier == "average"
     inputs = [inpt.identifier for inpt in process.dataInputs]
     assert "collection" in inputs
     assert "dims" in inputs
@@ -139,14 +139,14 @@ def test_smoke_execute_subset_time_and_area_cross_meridian(wps):
 
 def test_smoke_execute_c3s_cmip6_mon_average_dim(wps):
     inputs = [("collection", C3S_CMIP6_MON_COLLECTION), ("dims", "time")]
-    urls = wps.execute("average_dim", inputs)
+    urls = wps.execute("average", inputs)
     assert len(urls) == 1
     assert "rlds_Amon_INM-CM5-0_ssp245_r1i1p1f1_gr1_avg-t.nc" in urls[0]
 
 
 def test_smoke_execute_c3s_cmip6_day_average_dim(wps):
     inputs = [("collection", C3S_CMIP6_DAY_COLLECTION), ("dims", "time")]
-    urls = wps.execute("average_dim", inputs)
+    urls = wps.execute("average", inputs)
     # print(urls)
     assert len(urls) == 1
     assert "tas_day_HadGEM3-GC31-LL_ssp245_r1i1p1f3_gn_avg-t.nc" in urls[0]

--- a/tests/test_wps_average_dim.py
+++ b/tests/test_wps_average_dim.py
@@ -13,7 +13,7 @@ def test_wps_average_time_cmip5():
     datainputs = "collection=c3s-cmip5.output1.ICHEC.EC-EARTH.historical.day.atmos.day.r1i1p1.tas.latest"
     datainputs += ";dims=time"
     resp = client.get(
-        f"?service=WPS&request=Execute&version=1.0.0&identifier=average_dim&datainputs={datainputs}"
+        f"?service=WPS&request=Execute&version=1.0.0&identifier=average&datainputs={datainputs}"
     )
     assert_response_success(resp)
     assert "output" in get_output(resp.xml)
@@ -25,7 +25,7 @@ def test_wps_average_time_cmip6():
     datainputs = "collection=c3s-cmip6.ScenarioMIP.INM.INM-CM5-0.ssp245.r1i1p1f1.Amon.rlds.gr1.v20190619"
     datainputs += ";dims=time"
     resp = client.get(
-        f"?service=WPS&request=Execute&version=1.0.0&identifier=average_dim&datainputs={datainputs}"
+        f"?service=WPS&request=Execute&version=1.0.0&identifier=average&datainputs={datainputs}"
     )
     assert_response_success(resp)
     assert "output" in get_output(resp.xml)
@@ -37,7 +37,7 @@ def test_wps_average_latlon_cmip6():
     datainputs = "collection=c3s-cmip6.ScenarioMIP.INM.INM-CM5-0.ssp245.r1i1p1f1.Amon.rlds.gr1.v20190619"
     datainputs += ";dims=latitude;dims=longitude"
     resp = client.get(
-        f"?service=WPS&request=Execute&version=1.0.0&identifier=average_dim&datainputs={datainputs}"
+        f"?service=WPS&request=Execute&version=1.0.0&identifier=average&datainputs={datainputs}"
     )
     assert_response_success(resp)
     assert "output" in get_output(resp.xml)
@@ -47,7 +47,7 @@ def test_wps_average_no_dim():
     client = client_for(Service(processes=[AverageByDimension()], cfgfiles=[PYWPS_CFG]))
     datainputs = "collection=c3s-cmip6.ScenarioMIP.INM.INM-CM5-0.ssp245.r1i1p1f1.Amon.rlds.gr1.v20190619"
     resp = client.get(
-        f"?service=WPS&request=Execute&version=1.0.0&identifier=average_dim&datainputs={datainputs}"
+        f"?service=WPS&request=Execute&version=1.0.0&identifier=average&datainputs={datainputs}"
     )
     # print(resp.data)
     assert_process_exception(resp, code="MissingParameterValue")

--- a/tests/test_wps_caps.py
+++ b/tests/test_wps_caps.py
@@ -12,7 +12,7 @@ def test_wps_caps():
         "/wps:Capabilities" "/wps:ProcessOfferings" "/wps:Process" "/ows:Identifier"
     )
     assert sorted(names.split()) == [
-        "average_dim",
+        "average",
         "average_time",
         "dashboard",
         "orchestrate",

--- a/tests/testdata/wf_average_latlon_cmip6.json
+++ b/tests/testdata/wf_average_latlon_cmip6.json
@@ -15,7 +15,7 @@
               }
           },
           "average_rlds": {
-              "run": "average_dim",
+              "run": "average",
               "in": {
                   "collection": "subset_rlds_1/output",
                   "dims": ["latitude", "longitude"]


### PR DESCRIPTION
## Overview

Changes:

* Renamed `average_dim` process identifier to `average` to keep backward compatibility.
* Updated tests.

## Related Issue / Discussion

## Additional Information


