### PR TITLE
Fix 0.8.0

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -18,7 +18,7 @@ dependencies:
 - bottleneck>=1.3.1,<1.4
 - daops>=0.8.0,<0.9
 - clisops>=0.9.0,<0.10
-- roocs-utils>=0.5.0,<0.6
+- roocs-utils>=0.6.0,<0.7
 # workflow
 - networkx
 # provenance

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ psutil
 daops>=0.8.0,<0.9
 # daops @ git+https://github.com/roocs/daops@master#egg=daops
 clisops>=0.9.0,<0.10
-roocs-utils>=0.5.0,<0.6
+roocs-utils>=0.6.0,<0.7
 xarray>=0.20
 dask[complete]
 netcdf4

--- a/rook/director/director.py
+++ b/rook/director/director.py
@@ -103,7 +103,7 @@ class Director:
             return
 
         # TODO: quick fix for average. Don't use original files for average operator
-        if "dims" in self.inputs:
+        if "dims" in self.inputs or "freq" in self.inputs:
             return
 
         # Finally, check if the subset requirements can align with whole datasets

--- a/rook/etc/roocs.ini
+++ b/rook/etc/roocs.ini
@@ -1,1 +1,12 @@
 [rook]
+
+[project:c3s-cmip5]
+use_catalog = False
+
+[project:c3s-cordex]
+use_catalog = True
+data_node_root = https://data.mips.copernicus-climate.eu/thredds/fileServer/esg_c3s-cordex/
+
+[catalog]
+#intake_catalog_url = https://raw.githubusercontent.com/cp4cds/c3s_34g_manifests/master/intake/catalogs/c3s.yaml
+intake_catalog_url = https://github.com/cehbrecht/c3s_34g_manifests/raw/fix-intake-catalog/intake/catalogs/c3s.yaml

--- a/rook/etc/roocs.ini
+++ b/rook/etc/roocs.ini
@@ -1,12 +1,1 @@
 [rook]
-
-[project:c3s-cmip5]
-use_catalog = False
-
-[project:c3s-cordex]
-use_catalog = True
-data_node_root = https://data.mips.copernicus-climate.eu/thredds/fileServer/esg_c3s-cordex/
-
-[catalog]
-#intake_catalog_url = https://raw.githubusercontent.com/cp4cds/c3s_34g_manifests/master/intake/catalogs/c3s.yaml
-intake_catalog_url = https://github.com/cehbrecht/c3s_34g_manifests/raw/fix-intake-catalog/intake/catalogs/c3s.yaml

--- a/spec-list.txt
+++ b/spec-list.txt
@@ -27,7 +27,7 @@ https://conda.anaconda.org/conda-forge/linux-64/charls-2.3.4-h9c3ff4c_0.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/expat-2.4.8-h27087fc_0.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/freexl-1.0.6-h7f98852_0.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.10-h36c2ea0_0.tar.bz2
-https://conda.anaconda.org/conda-forge/linux-64/geos-3.10.1-h9c3ff4c_1.tar.bz2
+https://conda.anaconda.org/conda-forge/linux-64/geos-3.10.2-h9c3ff4c_0.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.1-h36c2ea0_2.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.13-h58526e2_1001.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/icu-69.1-h9c3ff4c_0.tar.bz2
@@ -77,7 +77,7 @@ https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.0.9-h166bdaf_7.ta
 https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.0.9-h166bdaf_7.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/libllvm11-11.1.0-hf817b99_3.tar.bz2
-https://conda.anaconda.org/conda-forge/linux-64/librttopo-1.1.0-h30b5eef_8.tar.bz2
+https://conda.anaconda.org/conda-forge/linux-64/librttopo-1.1.0-hf69c175_9.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.13-h7f98852_1004.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/readline-8.1-h46c0cb4_0.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.12-h27826a3_0.tar.bz2
@@ -141,7 +141,7 @@ https://conda.anaconda.org/conda-forge/noarch/iniconfig-1.1.1-pyh9f0ad1d_0.tar.b
 https://conda.anaconda.org/conda-forge/noarch/locket-0.2.0-py_2.tar.bz2
 https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/postgresql-14.2-hce44dc1_0.tar.bz2
-https://conda.anaconda.org/conda-forge/linux-64/proj-8.2.0-h277dcde_0.tar.bz2
+https://conda.anaconda.org/conda-forge/linux-64/proj-9.0.0-h93bde94_1.tar.bz2
 https://conda.anaconda.org/conda-forge/noarch/py-1.11.0-pyh6c4a22f_0.tar.bz2
 https://conda.anaconda.org/conda-forge/noarch/pycparser-2.21-pyhd8ed1ab_0.tar.bz2
 https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.0.8-pyhd8ed1ab_0.tar.bz2
@@ -168,7 +168,7 @@ https://conda.anaconda.org/conda-forge/linux-64/cffi-1.15.0-py37h036bc23_0.tar.b
 https://conda.anaconda.org/conda-forge/linux-64/cytoolz-0.11.2-py37h540881e_2.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/docutils-0.18.1-py37h89c1867_1.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/frozenlist-1.3.0-py37h540881e_1.tar.bz2
-https://conda.anaconda.org/conda-forge/linux-64/geotiff-1.7.0-h90a4e78_5.tar.bz2
+https://conda.anaconda.org/conda-forge/linux-64/geotiff-1.7.1-h509b78c_1.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/greenlet-1.1.2-py37hd23a5d3_2.tar.bz2
 https://conda.anaconda.org/conda-forge/noarch/html5lib-1.1-pyh9f0ad1d_0.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/importlib-metadata-4.11.3-py37h89c1867_1.tar.bz2
@@ -178,7 +178,7 @@ https://conda.anaconda.org/conda-forge/linux-64/kealib-1.4.14-h87e4c3c_3.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/libdap4-3.20.6-hd7c4107_2.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/libgd-2.3.3-h283352f_2.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/libnetcdf-4.8.1-mpi_mpich_h319fa22_1.tar.bz2
-https://conda.anaconda.org/conda-forge/linux-64/libspatialite-5.0.1-hf3ee066_12.tar.bz2
+https://conda.anaconda.org/conda-forge/linux-64/libspatialite-5.0.1-ha867d66_15.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/llvmlite-0.38.0-py37h0761922_1.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/loguru-0.6.0-py37h89c1867_1.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/lxml-4.8.0-py37h540881e_2.tar.bz2
@@ -197,7 +197,7 @@ https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.2-pyhd8ed1ab_0
 https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0-py37h540881e_4.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/rtree-1.0.0-py37h0b55af0_1.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/setuptools-59.8.0-py37h89c1867_1.tar.bz2
-https://conda.anaconda.org/conda-forge/linux-64/tiledb-2.5.3-hf3d3071_0.tar.bz2
+https://conda.anaconda.org/conda-forge/linux-64/tiledb-2.7.2-h3f4058f_0.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/tornado-6.1-py37h540881e_3.tar.bz2
 https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.1.1-hd8ed1ab_0.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-14.0.0-py37h540881e_1.tar.bz2
@@ -224,13 +224,13 @@ https://conda.anaconda.org/conda-forge/linux-64/numba-0.55.1-py37h2d894fd_0.tar.
 https://conda.anaconda.org/conda-forge/linux-64/numcodecs-0.9.1-py37hcd2ae1e_2.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/pandas-1.3.5-py37he8f5f7f_0.tar.bz2
 https://conda.anaconda.org/conda-forge/noarch/pip-22.0.4-pyhd8ed1ab_0.tar.bz2
-https://conda.anaconda.org/conda-forge/linux-64/poppler-21.11.0-ha39eefc_0.tar.bz2
-https://conda.anaconda.org/conda-forge/linux-64/pygeos-0.12.0-py37h9b0f7a3_0.tar.bz2
+https://conda.anaconda.org/conda-forge/linux-64/poppler-22.01.0-h1434ded_2.tar.bz2
+https://conda.anaconda.org/conda-forge/linux-64/pygeos-0.12.0-py37h8998c72_2.tar.bz2
 https://conda.anaconda.org/conda-forge/noarch/pygments-2.11.2-pyhd8ed1ab_0.tar.bz2
-https://conda.anaconda.org/conda-forge/linux-64/pyproj-3.2.1-py37hb589d83_5.tar.bz2
+https://conda.anaconda.org/conda-forge/linux-64/pyproj-3.2.1-py37h2040241_6.tar.bz2
 https://conda.anaconda.org/conda-forge/noarch/rdflib-6.1.1-pyhd8ed1ab_0.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/scipy-1.7.3-py37hf2a6cf1_0.tar.bz2
-https://conda.anaconda.org/conda-forge/linux-64/shapely-1.8.0-py37h9b0f7a3_4.tar.bz2
+https://conda.anaconda.org/conda-forge/linux-64/shapely-1.8.0-py37h8998c72_6.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/sqlalchemy-1.4.35-py37h540881e_0.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/yarl-1.7.2-py37h540881e_2.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.8.1-py37h540881e_1.tar.bz2
@@ -241,10 +241,10 @@ https://conda.anaconda.org/conda-forge/noarch/cligj-0.7.2-pyhd8ed1ab_1.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/distributed-2022.2.0-py37h89c1867_0.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/esmf-8.2.0-mpi_mpich_h4975321_100.tar.bz2
 https://conda.anaconda.org/conda-forge/noarch/geopandas-base-0.10.2-pyha770c72_1.tar.bz2
-https://conda.anaconda.org/conda-forge/linux-64/libgdal-3.4.0-h1504ab5_12.tar.bz2
+https://conda.anaconda.org/conda-forge/linux-64/libgdal-3.4.2-hda961b2_0.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.5.1-py37h1058ff1_0.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/netcdf4-1.5.8-nompi_py37hf784469_101.tar.bz2
-https://conda.anaconda.org/conda-forge/linux-64/pango-1.50.6-hbd2fdc8_0.tar.bz2
+https://conda.anaconda.org/conda-forge/linux-64/pango-1.50.7-hbd2fdc8_0.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/pluggy-1.0.0-py37h89c1867_3.tar.bz2
 https://conda.anaconda.org/conda-forge/noarch/pyopenssl-22.0.0-pyhd8ed1ab_0.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.0.2-py37hf9e9bfc_0.tar.bz2
@@ -255,7 +255,7 @@ https://conda.anaconda.org/conda-forge/noarch/zarr-2.11.3-pyhd8ed1ab_0.tar.bz2
 https://conda.anaconda.org/conda-forge/noarch/cf_xarray-0.7.2-pyhd8ed1ab_0.tar.bz2
 https://conda.anaconda.org/conda-forge/noarch/dask-2022.2.0-pyhd8ed1ab_0.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/esmpy-8.2.0-mpi_mpich_py37h7352969_101.tar.bz2
-https://conda.anaconda.org/conda-forge/linux-64/gdal-3.4.0-py37h9ed22ba_12.tar.bz2
+https://conda.anaconda.org/conda-forge/linux-64/gdal-3.4.2-py37hed81ac4_0.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/gtk2-2.24.33-h90689f9_2.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.52.5-h0a9e6e8_3.tar.bz2
 https://conda.anaconda.org/conda-forge/noarch/networkx-2.7.1-pyhd8ed1ab_0.tar.bz2
@@ -263,11 +263,11 @@ https://conda.anaconda.org/conda-forge/linux-64/pytest-7.1.1-py37h89c1867_1.tar.
 https://conda.anaconda.org/conda-forge/noarch/python-geotiff-0.2.4-pyhf58707e_0.tar.bz2
 https://conda.anaconda.org/conda-forge/noarch/urllib3-1.26.9-pyhd8ed1ab_0.tar.bz2
 https://conda.anaconda.org/conda-forge/noarch/elastic-transport-8.1.1-pyhd8ed1ab_0.tar.bz2
-https://conda.anaconda.org/conda-forge/linux-64/fiona-1.8.20-py37h2cf5250_4.tar.bz2
+https://conda.anaconda.org/conda-forge/linux-64/fiona-1.8.21-py37h1c464ab_1.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/graphviz-3.0.0-h5abf519_1.tar.bz2
 https://conda.anaconda.org/conda-forge/noarch/mapclassify-2.4.3-pyhd8ed1ab_0.tar.bz2
 https://conda.anaconda.org/conda-forge/noarch/requests-2.27.1-pyhd8ed1ab_0.tar.bz2
-https://conda.anaconda.org/conda-forge/noarch/roocs-utils-0.5.0-pyh6c4a22f_0.tar.bz2
+https://conda.anaconda.org/conda-forge/noarch/roocs-utils-0.6.0-pyh6c4a22f_0.tar.bz2
 https://conda.anaconda.org/conda-forge/noarch/xesmf-0.6.2-pyhd8ed1ab_0.tar.bz2
 https://conda.anaconda.org/conda-forge/noarch/elasticsearch-8.1.2-pyhd8ed1ab_0.tar.bz2
 https://conda.anaconda.org/conda-forge/noarch/folium-0.12.1.post1-pyhd8ed1ab_1.tar.bz2

--- a/tests/smoke/test_smoke_checks.py
+++ b/tests/smoke/test_smoke_checks.py
@@ -23,6 +23,8 @@ CMIP5_COLLECTION = (
 
 C3S_CORDEX_DAY_COLLECTION = "c3s-cordex.output.EUR-11.IPSL.IPSL-IPSL-CM5A-MR.rcp85.r1i1p1.IPSL-WRF381P.v1.day.tas.v20190919"  # noqa
 
+C3S_CORDEX_MON_COLLECTION = "c3s-cordex.output.EUR-11.CLMcom.MOHC-HadGEM2-ES.rcp85.r1i1p1.CLMcom-CCLM4-8-17.v1.mon.tas.v20150320"  # noqa
+
 WF_C3S_CMIP6 = json.dumps(
     {
         "doc": "subset+average on cmip6",
@@ -157,22 +159,14 @@ def test_smoke_execute_subset_time_and_area_cross_meridian(wps):
     assert "rlds_Amon_INM-CM5-0_ssp245_r1i1p1f1_gr1_20200116-20201216.nc" in urls[0]
 
 
-def test_smoke_execute_c3s_cmip6_mon_average_dim(wps):
+def test_smoke_execute_c3s_cmip6_average_dim(wps):
     inputs = [("collection", C3S_CMIP6_MON_COLLECTION), ("dims", "time")]
     urls = wps.execute("average", inputs)
     assert len(urls) == 1
     assert "rlds_Amon_INM-CM5-0_ssp245_r1i1p1f1_gr1_avg-t.nc" in urls[0]
 
 
-def test_smoke_execute_c3s_cmip6_day_average_dim(wps):
-    inputs = [("collection", C3S_CMIP6_DAY_COLLECTION), ("dims", "time")]
-    urls = wps.execute("average", inputs)
-    # print(urls)
-    assert len(urls) == 1
-    assert "tas_day_HadGEM3-GC31-LL_ssp245_r1i1p1f3_gn_avg-t.nc" in urls[0]
-
-
-def test_smoke_execute_c3s_cmip6_mon_average_time_year(wps):
+def test_smoke_execute_c3s_cmip6_average_time(wps):
     inputs = [("collection", C3S_CMIP6_MON_COLLECTION), ("freq", "year")]
     urls = wps.execute("average_time", inputs)
     assert len(urls) == 1
@@ -180,7 +174,7 @@ def test_smoke_execute_c3s_cmip6_mon_average_time_year(wps):
 
 
 def test_smoke_execute_c3s_cordex_average_dim(wps):
-    inputs = [("collection", C3S_CORDEX_DAY_COLLECTION), ("dims", "time")]
+    inputs = [("collection", C3S_CORDEX_MON_COLLECTION), ("dims", "time")]
     urls = wps.execute("average", inputs)
     # print(urls)
     assert len(urls) == 1

--- a/tests/smoke/test_smoke_checks.py
+++ b/tests/smoke/test_smoke_checks.py
@@ -129,7 +129,7 @@ def test_smoke_describe_process_orchestrate(wps):
 def test_smoke_execute_c3s_cmip5_subset(wps, tmp_path):
     inputs = [
         ("collection", C3S_CMIP5_DAY_COLLECTION),
-        ("time", "2020-01-01/2020-12-31"),
+        ("time", "2005-01-01/2005-12-31"),
     ]
     urls = wps.execute("subset", inputs)
     assert len(urls) == 1
@@ -148,6 +148,18 @@ def test_smoke_execute_c3s_cmip6_subset(wps, tmp_path):
     assert "rlds_Amon_INM-CM5-0_ssp245_r1i1p1f1_gr1_20200116-20201216.nc" in urls[0]
     ds = open_dataset(urls[0], tmp_path)
     assert "rlds" in ds.variables
+
+
+def test_smoke_execute_c3s_cordex_subset(wps, tmp_path):
+    inputs = [
+        ("collection", C3S_CORDEX_MON_COLLECTION),
+        ("time", "2020-01-01/2020-12-30"),
+    ]
+    urls = wps.execute("subset", inputs)
+    assert len(urls) == 1
+    assert "rlds_Amon_INM-CM5-0_ssp245_r1i1p1f1_gr1_20200116-20201216.nc" in urls[0]
+    ds = open_dataset(urls[0], tmp_path)
+    assert "tas" in ds.variables
 
 
 def test_smoke_execute_c3s_cmip6_subset_by_point(wps, tmp_path):
@@ -238,10 +250,7 @@ def test_smoke_execute_c3s_cmip5_orchestrate(wps):
     ]
     urls = wps.execute("orchestrate", inputs)
     assert len(urls) == 1
-    assert (
-        "tas_EUR-11_IPSL-IPSL-CM5A-MR_rcp85_r1i1p1_IPSL-WRF381P_v1_day_avg-t.nc"
-        in urls[0]
-    )
+    assert "tas_day_EC-EARTH_historical_r1i1p1_avg-t.nc" in urls[0]
 
 
 def test_smoke_execute_c3s_cmip6_orchestrate(wps):

--- a/tests/smoke/test_smoke_checks.py
+++ b/tests/smoke/test_smoke_checks.py
@@ -218,6 +218,6 @@ def test_smoke_execute_c3s_cordex_orchestrate(wps):
     urls = wps.execute("orchestrate", inputs)
     assert len(urls) == 1
     assert (
-        "tas_EUR-11_IPSL-IPSL-CM5A-MR_rcp85_r1i1p1_IPSL-WRF381P_v1_day_20060101-20060331.nc"
+        "tas_EUR-11_IPSL-IPSL-CM5A-MR_rcp85_r1i1p1_IPSL-WRF381P_v1_day_avg-t.nc"
         in urls[0]
     )

--- a/tests/smoke/test_smoke_checks.py
+++ b/tests/smoke/test_smoke_checks.py
@@ -189,7 +189,10 @@ def test_smoke_execute_c3s_cordex_average_time(wps):
     urls = wps.execute("average_time", inputs)
     # print(urls)
     assert len(urls) == 1
-    assert "tas_day_HadGEM3-GC31-LL_ssp245_r1i1p1f3_gn_avg-t.nc" in urls[0]
+    assert (
+        "tas_EUR-11_MOHC-HadGEM2-ES_rcp85_r1i1p1_CLMcom-CCLM4-8-17_v1_mon_200601-206012.nc"
+        in urls[0]
+    )
 
 
 def test_smoke_execute_c3s_cmip6_orchestrate(wps):

--- a/tests/smoke/test_smoke_checks.py
+++ b/tests/smoke/test_smoke_checks.py
@@ -245,7 +245,7 @@ def test_smoke_execute_c3s_cmip5_average_dim(wps):
     inputs = [("collection", C3S_CMIP5_MON_COLLECTION), ("dims", "time")]
     urls = wps.execute("average", inputs)
     assert len(urls) == 1
-    assert "tas_Amon_MPI-ESM-LR_historical_r1i1p1_avg-t.nc" in urls[0]
+    assert "tas_mon_MPI-ESM-LR_historical_r1i1p1_avg-t.nc" in urls[0]
 
 
 def test_smoke_execute_c3s_cmip5_average_time(wps):
@@ -253,7 +253,7 @@ def test_smoke_execute_c3s_cmip5_average_time(wps):
     urls = wps.execute("average_time", inputs)
     assert len(urls) == 1
     assert (
-        "tas_Amon_MPI-ESM-LR_historical_r1i1p1_18500101-20050101_avg-year.nc" in urls[0]
+        "tas_mon_MPI-ESM-LR_historical_r1i1p1_18500101-20050101_avg-year.nc" in urls[0]
     )
 
 

--- a/tests/smoke/test_smoke_checks.py
+++ b/tests/smoke/test_smoke_checks.py
@@ -179,6 +179,22 @@ def test_smoke_execute_c3s_cmip6_mon_average_time_year(wps):
     assert "rlds_Amon_INM-CM5-0_ssp245_r1i1p1f1_gr1_201501-210012.nc" in urls[0]
 
 
+def test_smoke_execute_c3s_cordex_average_dim(wps):
+    inputs = [("collection", C3S_CORDEX_DAY_COLLECTION), ("dims", "time")]
+    urls = wps.execute("average", inputs)
+    # print(urls)
+    assert len(urls) == 1
+    assert "tas_day_HadGEM3-GC31-LL_ssp245_r1i1p1f3_gn_avg-t.nc" in urls[0]
+
+
+def test_smoke_execute_c3s_cordex_average_time(wps):
+    inputs = [("collection", C3S_CORDEX_DAY_COLLECTION), ("freq", "year")]
+    urls = wps.execute("average_time", inputs)
+    # print(urls)
+    assert len(urls) == 1
+    assert "tas_day_HadGEM3-GC31-LL_ssp245_r1i1p1f3_gn_avg-t.nc" in urls[0]
+
+
 def test_smoke_execute_c3s_cmip6_orchestrate(wps):
     inputs = [
         ("workflow", ComplexDataInput(WF_C3S_CMIP6)),

--- a/tests/smoke/test_smoke_checks.py
+++ b/tests/smoke/test_smoke_checks.py
@@ -133,7 +133,7 @@ def test_smoke_execute_c3s_cmip5_subset(wps, tmp_path):
     ]
     urls = wps.execute("subset", inputs)
     assert len(urls) == 1
-    assert "rlds_Amon_INM-CM5-0_ssp245_r1i1p1f1_gr1_20200116-20201216.nc" in urls[0]
+    assert "tas_day_EC-EARTH_historical_r1i1p1_20050101-20051231.nc" in urls[0]
     ds = open_dataset(urls[0], tmp_path)
     assert "tas" in ds.variables
 
@@ -157,7 +157,10 @@ def test_smoke_execute_c3s_cordex_subset(wps, tmp_path):
     ]
     urls = wps.execute("subset", inputs)
     assert len(urls) == 1
-    assert "rlds_Amon_INM-CM5-0_ssp245_r1i1p1f1_gr1_20200116-20201216.nc" in urls[0]
+    assert (
+        "tas_EUR-11_MOHC-HadGEM2-ES_rcp85_r1i1p1_CLMcom-CCLM4-8-17_v1_mon_20200116-20201216.nc"
+        in urls[0]
+    )
     ds = open_dataset(urls[0], tmp_path)
     assert "tas" in ds.variables
 

--- a/tests/smoke/test_smoke_checks.py
+++ b/tests/smoke/test_smoke_checks.py
@@ -178,11 +178,14 @@ def test_smoke_execute_c3s_cordex_average_dim(wps):
     urls = wps.execute("average", inputs)
     # print(urls)
     assert len(urls) == 1
-    assert "tas_day_HadGEM3-GC31-LL_ssp245_r1i1p1f3_gn_avg-t.nc" in urls[0]
+    assert (
+        "tas_EUR-11_MOHC-HadGEM2-ES_rcp85_r1i1p1_CLMcom-CCLM4-8-17_v1_mon_avg-t.nc"
+        in urls[0]
+    )
 
 
 def test_smoke_execute_c3s_cordex_average_time(wps):
-    inputs = [("collection", C3S_CORDEX_DAY_COLLECTION), ("freq", "year")]
+    inputs = [("collection", C3S_CORDEX_MON_COLLECTION), ("freq", "year")]
     urls = wps.execute("average_time", inputs)
     # print(urls)
     assert len(urls) == 1

--- a/tests/smoke/test_smoke_checks.py
+++ b/tests/smoke/test_smoke_checks.py
@@ -170,7 +170,10 @@ def test_smoke_execute_c3s_cmip6_average_time(wps):
     inputs = [("collection", C3S_CMIP6_MON_COLLECTION), ("freq", "year")]
     urls = wps.execute("average_time", inputs)
     assert len(urls) == 1
-    assert "rlds_Amon_INM-CM5-0_ssp245_r1i1p1f1_gr1_201501-210012.nc" in urls[0]
+    assert (
+        "rlds_Amon_INM-CM5-0_ssp245_r1i1p1f1_gr1_20150101-21000101_avg-year.nc"
+        in urls[0]
+    )
 
 
 def test_smoke_execute_c3s_cordex_average_dim(wps):
@@ -190,7 +193,7 @@ def test_smoke_execute_c3s_cordex_average_time(wps):
     # print(urls)
     assert len(urls) == 1
     assert (
-        "tas_EUR-11_MOHC-HadGEM2-ES_rcp85_r1i1p1_CLMcom-CCLM4-8-17_v1_mon_200601-206012.nc"
+        "tas_EUR-11_MOHC-HadGEM2-ES_rcp85_r1i1p1_CLMcom-CCLM4-8-17_v1_mon_20060101-20990101_avg-year.nc"
         in urls[0]
     )
 

--- a/tests/smoke/test_smoke_checks.py
+++ b/tests/smoke/test_smoke_checks.py
@@ -21,6 +21,10 @@ C3S_CMIP5_DAY_COLLECTION = (
     "c3s-cmip5.output1.ICHEC.EC-EARTH.historical.day.atmos.day.r1i1p1.tas.latest"
 )
 
+C3S_CMIP5_MON_COLLECTION = (
+    "c3s-cmip5.output1.MPI-M.MPI-ESM-LR.historical.mon.atmos.Amon.r1i1p1.tas.v20120315"
+)
+
 C3S_CORDEX_DAY_COLLECTION = "c3s-cordex.output.EUR-11.IPSL.IPSL-IPSL-CM5A-MR.rcp85.r1i1p1.IPSL-WRF381P.v1.day.tas.v20190919"  # noqa
 
 C3S_CORDEX_MON_COLLECTION = "c3s-cordex.output.EUR-11.CLMcom.MOHC-HadGEM2-ES.rcp85.r1i1p1.CLMcom-CCLM4-8-17.v1.mon.tas.v20150320"  # noqa
@@ -238,17 +242,19 @@ def test_smoke_execute_subset_time_and_area_cross_meridian(wps):
 
 
 def test_smoke_execute_c3s_cmip5_average_dim(wps):
-    inputs = [("collection", C3S_CMIP5_DAY_COLLECTION), ("dims", "time")]
+    inputs = [("collection", C3S_CMIP5_MON_COLLECTION), ("dims", "time")]
     urls = wps.execute("average", inputs)
     assert len(urls) == 1
-    assert "tas_day_EC-EARTH_historical_r1i1p1_avg-t.nc" in urls[0]
+    assert "tas_Amon_MPI-ESM-LR_historical_r1i1p1_avg-t.nc" in urls[0]
 
 
 def test_smoke_execute_c3s_cmip5_average_time(wps):
-    inputs = [("collection", C3S_CMIP5_DAY_COLLECTION), ("freq", "year")]
+    inputs = [("collection", C3S_CMIP5_MON_COLLECTION), ("freq", "year")]
     urls = wps.execute("average_time", inputs)
     assert len(urls) == 1
-    assert "tas_day_EC-EARTH_historical_r1i1p1_18500101-20090101_avg-year.nc" in urls[0]
+    assert (
+        "tas_Amon_MPI-ESM-LR_historical_r1i1p1_18500101-20050101_avg-year.nc" in urls[0]
+    )
 
 
 def test_smoke_execute_c3s_cmip6_average_dim(wps):

--- a/tests/smoke/test_smoke_checks.py
+++ b/tests/smoke/test_smoke_checks.py
@@ -58,8 +58,8 @@ WF_C3S_CORDEX = json.dumps(
                 },
             },
             "average": {
-                "run": "average_time",
-                "in": {"collection": "subset/output", "freq": "year"},
+                "run": "average",
+                "in": {"collection": "subset/output", "dims": "time"},
             },
         },
     }

--- a/tests/smoke/test_smoke_checks.py
+++ b/tests/smoke/test_smoke_checks.py
@@ -165,6 +165,19 @@ def test_smoke_execute_c3s_cordex_subset(wps, tmp_path):
     assert "tas" in ds.variables
 
 
+def test_smoke_execute_c3s_cmip5_subset_by_point(wps, tmp_path):
+    inputs = [
+        ("collection", C3S_CMIP5_DAY_COLLECTION),
+        ("time", "2005-01-01/2005-12-31"),
+        ("time_components", "month:jan,feb,mar"),
+    ]
+    urls = wps.execute("subset", inputs)
+    assert len(urls) == 1
+    assert "tas_day_EC-EARTH_historical_r1i1p1_20050101-20050330.nc" in urls[0]
+    ds = open_dataset(urls[0], tmp_path)
+    assert "tas" in ds.variables
+
+
 def test_smoke_execute_c3s_cmip6_subset_by_point(wps, tmp_path):
     inputs = [
         ("collection", C3S_CMIP6_MON_COLLECTION),
@@ -176,6 +189,22 @@ def test_smoke_execute_c3s_cmip6_subset_by_point(wps, tmp_path):
     assert "rlds_Amon_INM-CM5-0_ssp245_r1i1p1f1_gr1_20200116-20200316.nc" in urls[0]
     ds = open_dataset(urls[0], tmp_path)
     assert "rlds" in ds.variables
+
+
+def test_smoke_execute_c3s_cordex_subset_by_point(wps, tmp_path):
+    inputs = [
+        ("collection", C3S_CORDEX_MON_COLLECTION),
+        ("time", "2020-01-01/2020-12-30"),
+        ("time_components", "month:jan,feb,mar"),
+    ]
+    urls = wps.execute("subset", inputs)
+    assert len(urls) == 1
+    assert (
+        "tas_EUR-11_MOHC-HadGEM2-ES_rcp85_r1i1p1_CLMcom-CCLM4-8-17_v1_mon_20200101-20200330.nc"
+        in urls[0]
+    )
+    ds = open_dataset(urls[0], tmp_path)
+    assert "tas" in ds.variables
 
 
 def test_smoke_execute_subset_original_files(wps):
@@ -206,6 +235,23 @@ def test_smoke_execute_subset_time_and_area_cross_meridian(wps):
     urls = wps.execute("subset", inputs)
     assert len(urls) == 1
     assert "rlds_Amon_INM-CM5-0_ssp245_r1i1p1f1_gr1_20200116-20201216.nc" in urls[0]
+
+
+def test_smoke_execute_c3s_cmip5_average_dim(wps):
+    inputs = [("collection", C3S_CMIP5_DAY_COLLECTION), ("dims", "time")]
+    urls = wps.execute("average", inputs)
+    assert len(urls) == 1
+    assert "rlds_Amon_INM-CM5-0_ssp245_r1i1p1f1_gr1_avg-t.nc" in urls[0]
+
+
+def test_smoke_execute_c3s_cmip5_average_time(wps):
+    inputs = [("collection", C3S_CMIP5_DAY_COLLECTION), ("freq", "year")]
+    urls = wps.execute("average_time", inputs)
+    assert len(urls) == 1
+    assert (
+        "rlds_Amon_INM-CM5-0_ssp245_r1i1p1f1_gr1_20150101-21000101_avg-year.nc"
+        in urls[0]
+    )
 
 
 def test_smoke_execute_c3s_cmip6_average_dim(wps):

--- a/tests/smoke/test_smoke_checks.py
+++ b/tests/smoke/test_smoke_checks.py
@@ -21,9 +21,11 @@ CMIP5_COLLECTION = (
     "c3s-cmip5.output1.ICHEC.EC-EARTH.historical.day.atmos.day.r1i1p1.tas.latest"
 )
 
-WF_SUBSET_AVERAGE = json.dumps(
+C3S_CORDEX_DAY_COLLECTION = "c3s-cordex.output.EUR-11.IPSL.IPSL-IPSL-CM5A-MR.rcp85.r1i1p1.IPSL-WRF381P.v1.day.tas.v20190919"  # noqa
+
+WF_C3S_CMIP6 = json.dumps(
     {
-        "doc": "subset+average on cmip6 rlds",
+        "doc": "subset+average on cmip6",
         "inputs": {"ds": [C3S_CMIP6_MON_COLLECTION]},
         "outputs": {"output": "average_ds/output"},
         "steps": {
@@ -34,6 +36,24 @@ WF_SUBSET_AVERAGE = json.dumps(
             "average_ds": {
                 "run": "average",
                 "in": {"collection": "subset_ds/output", "dims": "time"},
+            },
+        },
+    }
+)
+
+WF_C3S_CORDEX = json.dumps(
+    {
+        "doc": "subset on c3s-cordex",
+        "inputs": {"ds": [C3S_CORDEX_DAY_COLLECTION]},
+        "outputs": {"output": "subset/output"},
+        "steps": {
+            "subset": {
+                "run": "subset",
+                "in": {
+                    "collection": "inputs/ds",
+                    "time": "2006/2006",
+                    "time_components": "month:jan,feb,mar",
+                },
             },
         },
     }
@@ -159,9 +179,18 @@ def test_smoke_execute_c3s_cmip6_mon_average_time_year(wps):
     assert "rlds_Amon_INM-CM5-0_ssp245_r1i1p1f1_gr1_201501-210012.nc" in urls[0]
 
 
-def test_smoke_execute_orchestrate(wps):
+def test_smoke_execute_c3s_cmip6_orchestrate(wps):
     inputs = [
-        ("workflow", ComplexDataInput(WF_SUBSET_AVERAGE)),
+        ("workflow", ComplexDataInput(WF_C3S_CMIP6)),
+    ]
+    urls = wps.execute("orchestrate", inputs)
+    assert len(urls) == 1
+    assert "rlds_Amon_INM-CM5-0_ssp245_r1i1p1f1_gr1_avg-t.nc" in urls[0]
+
+
+def test_smoke_execute_c3s_cordex_orchestrate(wps):
+    inputs = [
+        ("workflow", ComplexDataInput(WF_C3S_CORDEX)),
     ]
     urls = wps.execute("orchestrate", inputs)
     assert len(urls) == 1

--- a/tests/smoke/test_smoke_checks.py
+++ b/tests/smoke/test_smoke_checks.py
@@ -173,7 +173,7 @@ def test_smoke_execute_c3s_cmip5_subset_by_point(wps, tmp_path):
     ]
     urls = wps.execute("subset", inputs)
     assert len(urls) == 1
-    assert "tas_day_EC-EARTH_historical_r1i1p1_20050101-20050330.nc" in urls[0]
+    assert "tas_day_EC-EARTH_historical_r1i1p1_20050101-20050331.nc" in urls[0]
     ds = open_dataset(urls[0], tmp_path)
     assert "tas" in ds.variables
 
@@ -200,7 +200,7 @@ def test_smoke_execute_c3s_cordex_subset_by_point(wps, tmp_path):
     urls = wps.execute("subset", inputs)
     assert len(urls) == 1
     assert (
-        "tas_EUR-11_MOHC-HadGEM2-ES_rcp85_r1i1p1_CLMcom-CCLM4-8-17_v1_mon_20200101-20200330.nc"
+        "tas_EUR-11_MOHC-HadGEM2-ES_rcp85_r1i1p1_CLMcom-CCLM4-8-17_v1_mon_20200116-20200316.nc"
         in urls[0]
     )
     ds = open_dataset(urls[0], tmp_path)
@@ -241,17 +241,14 @@ def test_smoke_execute_c3s_cmip5_average_dim(wps):
     inputs = [("collection", C3S_CMIP5_DAY_COLLECTION), ("dims", "time")]
     urls = wps.execute("average", inputs)
     assert len(urls) == 1
-    assert "rlds_Amon_INM-CM5-0_ssp245_r1i1p1f1_gr1_avg-t.nc" in urls[0]
+    assert "tas_day_EC-EARTH_historical_r1i1p1_avg-t.nc" in urls[0]
 
 
 def test_smoke_execute_c3s_cmip5_average_time(wps):
     inputs = [("collection", C3S_CMIP5_DAY_COLLECTION), ("freq", "year")]
     urls = wps.execute("average_time", inputs)
     assert len(urls) == 1
-    assert (
-        "rlds_Amon_INM-CM5-0_ssp245_r1i1p1f1_gr1_20150101-21000101_avg-year.nc"
-        in urls[0]
-    )
+    assert "tas_day_EC-EARTH_historical_r1i1p1_18500101-20090101_avg-year.nc" in urls[0]
 
 
 def test_smoke_execute_c3s_cmip6_average_dim(wps):

--- a/tests/smoke/test_smoke_checks.py
+++ b/tests/smoke/test_smoke_checks.py
@@ -156,7 +156,7 @@ def test_smoke_execute_c3s_cmip6_mon_average_time_year(wps):
     inputs = [("collection", C3S_CMIP6_MON_COLLECTION), ("freq", "year")]
     urls = wps.execute("average_time", inputs)
     assert len(urls) == 1
-    assert "rlds_Amon_INM-CM5-0_ssp245_r1i1p1f1_gr1_avg-t.nc" in urls[0]
+    assert "rlds_Amon_INM-CM5-0_ssp245_r1i1p1f1_gr1_201501-210012.nc" in urls[0]
 
 
 def test_smoke_execute_orchestrate(wps):

--- a/tests/smoke/test_smoke_checks.py
+++ b/tests/smoke/test_smoke_checks.py
@@ -29,15 +29,15 @@ WF_C3S_CMIP6 = json.dumps(
     {
         "doc": "subset+average on cmip6",
         "inputs": {"ds": [C3S_CMIP6_MON_COLLECTION]},
-        "outputs": {"output": "average_ds/output"},
+        "outputs": {"output": "average/output"},
         "steps": {
-            "subset_ds": {
+            "subset": {
                 "run": "subset",
                 "in": {"collection": "inputs/ds", "time": "2020-01-01/2020-12-31"},
             },
-            "average_ds": {
+            "average": {
                 "run": "average",
-                "in": {"collection": "subset_ds/output", "dims": "time"},
+                "in": {"collection": "subset/output", "dims": "time"},
             },
         },
     }
@@ -47,7 +47,7 @@ WF_C3S_CORDEX = json.dumps(
     {
         "doc": "subset on c3s-cordex",
         "inputs": {"ds": [C3S_CORDEX_DAY_COLLECTION]},
-        "outputs": {"output": "subset/output"},
+        "outputs": {"output": "average/output"},
         "steps": {
             "subset": {
                 "run": "subset",
@@ -56,6 +56,10 @@ WF_C3S_CORDEX = json.dumps(
                     "time": "2006/2006",
                     "time_components": "month:jan,feb,mar",
                 },
+            },
+            "average": {
+                "run": "average_time",
+                "in": {"collection": "subset/output", "freq": "year"},
             },
         },
     }

--- a/tests/smoke/test_smoke_checks.py
+++ b/tests/smoke/test_smoke_checks.py
@@ -194,4 +194,7 @@ def test_smoke_execute_c3s_cordex_orchestrate(wps):
     ]
     urls = wps.execute("orchestrate", inputs)
     assert len(urls) == 1
-    assert "rlds_Amon_INM-CM5-0_ssp245_r1i1p1f1_gr1_avg-t.nc" in urls[0]
+    assert (
+        "tas_EUR-11_IPSL-IPSL-CM5A-MR_rcp85_r1i1p1_IPSL-WRF381P_v1_day_20060101-20060331.nc"
+        in urls[0]
+    )


### PR DESCRIPTION
## Overview

This PR fixes release 0.8.0.

Changes:

* Added smoke tests for c3s-cmip5 and c3s-cordex.
* Fixed `director` for new `average_time` operator.
* Updated to latest `roocs-utils` 0.6.0.

## Related Issue / Discussion

## Additional Information

Links to other issues or sources.
