### PR TITLE
Update prov c4i

### DIFF
--- a/rook/provenance.py
+++ b/rook/provenance.py
@@ -21,7 +21,7 @@ PROVONE_DATA = PROVONE["Data"]
 PROVONE_EXECUTION = PROVONE["Execution"]
 
 # dcterms namespace
-DCTERMS = Namespace("dctterms", uri="http://purl.org/dc/terms/")
+DCTERMS = Namespace("dcterms", uri="http://purl.org/dc/terms/")
 DCTERMS_SOURCE = DCTERMS["source"]
 
 # roocs namespace

--- a/rook/provenance.py
+++ b/rook/provenance.py
@@ -21,7 +21,7 @@ PROVONE_DATA = PROVONE["Data"]
 PROVONE_EXECUTION = PROVONE["Execution"]
 
 # dcterms namespace
-DCTERMS = Namespace("dct", uri="http://purl.org/dc/terms/")
+DCTERMS = Namespace("dctterms", uri="http://purl.org/dc/terms/")
 DCTERMS_SOURCE = DCTERMS["source"]
 
 # roocs namespace


### PR DESCRIPTION
## Overview

This PR the provenance information as requested by c4i.

Changes:

* Rename `dct` to `dcterms`.

## Related Issue / Discussion

## Additional Information


