### PR TITLE
update regrid parameters

### DIFF
--- a/rook/processes/wps_regrid.py
+++ b/rook/processes/wps_regrid.py
@@ -33,18 +33,18 @@ class Regrid(Process):
                 data_type="string",
                 min_occurs=1,
                 max_occurs=1,
-                allowed_values=["conservative", "patch", "nearest_s2d", "bilinear"],
+                allowed_values=["nearest_s2d", "bilinear", "conservative",  "patch"],
                 default="nearest_s2d",
             ),
             LiteralInput(
                 "grid",
                 "Regrid target grid",
-                abstract="Please specify output grid resolution for regridding. Default: 1deg",
+                abstract="Please specify output grid resolution for regridding. Default: auto",
                 data_type="string",
                 min_occurs=1,
                 max_occurs=1,
-                allowed_values=["1deg", "2deg_lsm", "0pt25deg_era5_lsm"],
-                default="1deg",
+                allowed_values=["auto", "0pt25deg", "0pt25deg_era5", "0pt5deg_lsm",  "0pt625x0pt5deg", "0pt75deg", "1deg", "1pt25deg", "2pt5deg"],
+                default="auto",
             ),
         ]
         outputs = [
@@ -100,7 +100,8 @@ class Regrid(Process):
             "apply_fixes": False,
             "pre_checked": False,
             "method": parse_wps_input(request.inputs, "method", default="nearest_s2d"),
-            "grid": parse_wps_input(request.inputs, "grid", default="1deg"),
+            "grid": parse_wps_input(request.inputs, "grid", default="auto"),
+            "adaptive_masking_threshold": 0.5,
         }
         # print(inputs)
 

--- a/rook/processes/wps_regrid.py
+++ b/rook/processes/wps_regrid.py
@@ -33,7 +33,7 @@ class Regrid(Process):
                 data_type="string",
                 min_occurs=1,
                 max_occurs=1,
-                allowed_values=["nearest_s2d", "bilinear", "conservative",  "patch"],
+                allowed_values=["nearest_s2d", "bilinear", "conservative", "patch"],
                 default="nearest_s2d",
             ),
             LiteralInput(
@@ -43,7 +43,17 @@ class Regrid(Process):
                 data_type="string",
                 min_occurs=1,
                 max_occurs=1,
-                allowed_values=["auto", "0pt25deg", "0pt25deg_era5", "0pt5deg_lsm",  "0pt625x0pt5deg", "0pt75deg", "1deg", "1pt25deg", "2pt5deg"],
+                allowed_values=[
+                    "auto",
+                    "0pt25deg",
+                    "0pt25deg_era5",
+                    "0pt5deg_lsm",
+                    "0pt625x0pt5deg",
+                    "0pt75deg",
+                    "1deg",
+                    "1pt25deg",
+                    "2pt5deg"
+                ],
                 default="auto",
             ),
         ]

--- a/rook/provenance.py
+++ b/rook/provenance.py
@@ -117,6 +117,7 @@ class Provenance(object):
             "freq",
             "method",
             "grid",
+            "adaptive_masking_threshold",
             "apply_fixes",
             "apply_average",
         ]:

--- a/tests/test_wps_regrid.py
+++ b/tests/test_wps_regrid.py
@@ -9,11 +9,10 @@ from .common import PYWPS_CFG, get_output
 
 
 def test_wps_regrid_cmip6():
-    # test the case where the inventory is used
     client = client_for(Service(processes=[Regrid()], cfgfiles=[PYWPS_CFG]))
     datainputs = "collection=c3s-cmip6.ScenarioMIP.INM.INM-CM5-0.ssp245.r1i1p1f1.Amon.rlds.gr1.v20190619"
     datainputs += ";method=nearest_s2d"
-    datainputs += ";grid=1deg"
+    datainputs += ";grid=auto"
     resp = client.get(
         f"?service=WPS&request=Execute&version=1.0.0&identifier=regrid&datainputs={datainputs}"
     )


### PR DESCRIPTION
## Overview

This PR updates the parameters of the regrid operator:

* grid: auto (default), 0pt25deg, 0pt25deg_era5, 0pt5deg_lsm,  0pt625x0pt5deg, 0pt75deg, 1deg, 1pt25deg, 2pt5deg
* method: nearest_s2d (default), bilinear, conservative,  patch
* adaptive_masking_threshold: 0.5


## Related Issue / Discussion

## Additional Information


