### PR TITLE
Update decadal fixes

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,7 @@ dependencies:
 # daops
 - cftime>=1.2.1
 - xarray>=0.20,<0.22
-- cf_xarray>=0.7
+- cf_xarray>=0.7,<=0.8.4
 - dask>=2021.12
 - netcdf4>=1.4
 - bottleneck>=1.3.1,<1.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ clisops>=0.9.6,<0.11
 roocs-utils>=0.6.4,<0.7
 # roocs-utils @ git+https://github.com/roocs/roocs-utils@master#egg=roocs-utils
 xarray>=0.20,<0.22
+cf-xarray<=0.8.4
 dask[complete]
 netcdf4
 # workflow

--- a/rook/utils/concat_utils.py
+++ b/rook/utils/concat_utils.py
@@ -80,8 +80,9 @@ class Concat(Operation):
         dims = dimension_parameter.DimensionParameter(
             self.params.get("dims", None)
         ).value
-        standard_name = dims[0]
-        dim = coord_by_standard_name.get(standard_name, None)
+        # standard_name = dims[0]
+        # dim = coord_by_standard_name.get(standard_name, None)
+        dim = dims[0]
 
         processed_ds = xr.concat(
             datasets,
@@ -90,7 +91,7 @@ class Concat(Operation):
         processed_ds = processed_ds.assign_coords(
             {dim: (dim, np.array(processed_ds[dim].values, dtype="int32"))}
         )
-        processed_ds.coords[dim].attrs = {"standard_name": standard_name}
+        # processed_ds.coords[dim].attrs = {"standard_name": standard_name}
         # optional: average
         if self.params.get("apply_average", False):
             processed_ds = average(processed_ds, dims=["realization"])

--- a/rook/utils/decadal_fixes.py
+++ b/rook/utils/decadal_fixes.py
@@ -120,7 +120,7 @@ def decadal_fix_4(ds_id, ds):
 def decadal_fix_5(ds_id, ds):
     operands = {
         "var_id": "realization",
-        "value": "1",
+        "value": ds.attrs.get("realization_index"),
         "dtype": "int32",
         "attrs": {
             "long_name": "realization",


### PR DESCRIPTION
## Overview

This PR update the cmip6 decadal fixes.

Changes:

* Set new data variable `realization` to the value of `realization_index`.
* Use the variable `realization` in the concat operation instead of the `realization_index`.
* Don't use the cf standard name for `realization`.

## Related Issue / Discussion

## Additional Information


