### PR TITLE
allow pywps 4.6.x

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     steps:
     - name: Checkout repository and submodules
       uses: actions/checkout@v2

--- a/environment.yml
+++ b/environment.yml
@@ -4,8 +4,8 @@ channels:
 - defaults
 dependencies:
 - pip
-- python>=3.8,<3.11
-- pywps>=4.5.2,<4.6
+- python>=3.8
+- pywps>=4.5.2,<4.7
 - jinja2
 - click
 - psutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pywps>=4.5.2,<4.6
+pywps>=4.5.2,<4.7
 jinja2
 click
 psutil


### PR DESCRIPTION
## Overview

This PR allows latest pywps version 4.6.x.

Changes:

* update pywps
* run tests also on Python 3.11

## Related Issue / Discussion

## Additional Information


