### PR TITLE
Fix time components

### DIFF
--- a/rook/processes/wps_concat.py
+++ b/rook/processes/wps_concat.py
@@ -7,7 +7,7 @@ from pywps.app.Common import Metadata
 # from pywps.inout.outputs import MetaFile, MetaLink4
 
 from ..director import wrap_director
-from ..utils.input_utils import parse_wps_input, fix_time_components
+from ..utils.input_utils import parse_wps_input
 from ..utils.metalink_utils import build_metalink
 from ..utils.response_utils import populate_response
 from ..utils.concat_utils import run_concat
@@ -137,7 +137,6 @@ class Concat(Process):
         collection = parse_wps_input(
             request.inputs, "collection", as_sequence=True, must_exist=True
         )
-        # print(collection)
         inputs = {
             "collection": collection,
             "output_dir": self.workdir,
@@ -149,14 +148,13 @@ class Concat(Process):
                 request.inputs, "apply_average", default=False
             ),
             "time": parse_wps_input(request.inputs, "time", default=None),
-            "time_components": fix_time_components(
-                parse_wps_input(request.inputs, "time_components", default=None)
+            "time_components": parse_wps_input(
+                request.inputs, "time_components", default=None
             ),
             "dims": parse_wps_input(
                 request.inputs, "dims", as_sequence=True, default=None
             ),
         }
-        # print(inputs)
 
         # Let the director manage the processing or redirection to original files
         director = wrap_director(collection, inputs, run_concat)

--- a/rook/processes/wps_concat.py
+++ b/rook/processes/wps_concat.py
@@ -1,13 +1,13 @@
 import logging
-import os
 
 from pywps import FORMATS, ComplexOutput, Format, LiteralInput, Process
 from pywps.app.Common import Metadata
-from pywps.app.exceptions import ProcessError
-from pywps.inout.outputs import MetaFile, MetaLink4
+
+# from pywps.app.exceptions import ProcessError
+# from pywps.inout.outputs import MetaFile, MetaLink4
 
 from ..director import wrap_director
-from ..utils.input_utils import parse_wps_input
+from ..utils.input_utils import parse_wps_input, fix_time_components
 from ..utils.metalink_utils import build_metalink
 from ..utils.response_utils import populate_response
 from ..utils.concat_utils import run_concat
@@ -149,8 +149,8 @@ class Concat(Process):
                 request.inputs, "apply_average", default=False
             ),
             "time": parse_wps_input(request.inputs, "time", default=None),
-            "time_components": parse_wps_input(
-                request.inputs, "time_components", default=None
+            "time_components": fix_time_components(
+                parse_wps_input(request.inputs, "time_components", default=None)
             ),
             "dims": parse_wps_input(
                 request.inputs, "dims", as_sequence=True, default=None

--- a/rook/processes/wps_subset.py
+++ b/rook/processes/wps_subset.py
@@ -1,13 +1,13 @@
 import logging
-import os
 
 from pywps import FORMATS, ComplexOutput, Format, LiteralInput, Process
 from pywps.app.Common import Metadata
-from pywps.app.exceptions import ProcessError
-from pywps.inout.outputs import MetaFile, MetaLink4
+
+# from pywps.app.exceptions import ProcessError
+# from pywps.inout.outputs import MetaFile, MetaLink4
 
 from ..director import wrap_director
-from ..utils.input_utils import parse_wps_input
+from ..utils.input_utils import parse_wps_input, fix_time_components
 from ..utils.metalink_utils import build_metalink
 from ..utils.response_utils import populate_response
 from ..utils.subset_utils import run_subset
@@ -151,8 +151,8 @@ class Subset(Process):
                 request.inputs, "original_files", default=False
             ),
             "time": parse_wps_input(request.inputs, "time", default=None),
-            "time_components": parse_wps_input(
-                request.inputs, "time_components", default=None
+            "time_components": fix_time_components(
+                parse_wps_input(request.inputs, "time_components", default=None)
             ),
             "level": parse_wps_input(request.inputs, "level", default=None),
             "area": parse_wps_input(request.inputs, "area", default=None),

--- a/rook/processes/wps_subset.py
+++ b/rook/processes/wps_subset.py
@@ -7,7 +7,7 @@ from pywps.app.Common import Metadata
 # from pywps.inout.outputs import MetaFile, MetaLink4
 
 from ..director import wrap_director
-from ..utils.input_utils import parse_wps_input, fix_time_components
+from ..utils.input_utils import parse_wps_input
 from ..utils.metalink_utils import build_metalink
 from ..utils.response_utils import populate_response
 from ..utils.subset_utils import run_subset
@@ -151,8 +151,8 @@ class Subset(Process):
                 request.inputs, "original_files", default=False
             ),
             "time": parse_wps_input(request.inputs, "time", default=None),
-            "time_components": fix_time_components(
-                parse_wps_input(request.inputs, "time_components", default=None)
+            "time_components": parse_wps_input(
+                request.inputs, "time_components", default=None
             ),
             "level": parse_wps_input(request.inputs, "level", default=None),
             "area": parse_wps_input(request.inputs, "area", default=None),

--- a/rook/utils/concat_utils.py
+++ b/rook/utils/concat_utils.py
@@ -18,6 +18,7 @@ from clisops.ops import subset
 from clisops.core.average import average_over_dims as average
 
 from .decadal_fixes import apply_decadal_fixes
+from .input_utils import fix_parameters
 
 coord_by_standard_name = {
     "realization": "realization",
@@ -125,6 +126,8 @@ def _concat(
 
 
 def run_concat(args):
+    args = fix_parameters(args)
+
     result = concat(**args)
     return result.file_uris
 

--- a/rook/utils/input_utils.py
+++ b/rook/utils/input_utils.py
@@ -6,6 +6,26 @@ from roocs_utils.exceptions import InvalidProject
 from rook import CONFIG
 
 
+def fix_time_components(tc):
+    # Remove reduntant time-component parts to avoid for example issues with 360day calendars
+    tc_all_months = "month:jan,feb,mar,apr,may,jun,jul,aug,sep,oct,nov,dec"
+    tc_all_months_2 = "month:01,02,03,04,05,06,07,08,09,10,11,12"
+    tc_all_days = "day:01,02,03,04,05,06,07,08,09,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"
+
+    tc_parts = tc.split("|")
+    new_tc_parts = []
+    for tc_part in tc_parts:
+        if tc_part == tc_all_months:
+            continue
+        if tc_part == tc_all_months_2:
+            continue
+        if tc_part == tc_all_days:
+            continue
+        new_tc_parts.append(tc_part)
+    new_tc = "|".join(new_tc_parts)
+    return new_tc
+
+
 def parse_wps_input(inputs, key, as_sequence=False, must_exist=False, default=None):
     if not inputs.get(key):
         if must_exist:

--- a/rook/utils/input_utils.py
+++ b/rook/utils/input_utils.py
@@ -7,10 +7,13 @@ from rook import CONFIG
 
 
 def fix_time_components(tc):
-    # Remove reduntant time-component parts to avoid for example issues with 360day calendars
+    # Remove redundant time-component parts to avoid for example issues with 360day calendars.
     tc_all_months = "month:jan,feb,mar,apr,may,jun,jul,aug,sep,oct,nov,dec"
     tc_all_months_2 = "month:01,02,03,04,05,06,07,08,09,10,11,12"
     tc_all_days = "day:01,02,03,04,05,06,07,08,09,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"
+
+    if not tc:
+        return None
 
     tc_parts = tc.split("|")
     new_tc_parts = []

--- a/rook/utils/input_utils.py
+++ b/rook/utils/input_utils.py
@@ -5,6 +5,10 @@ from roocs_utils.project_utils import url_to_file_path
 from roocs_utils.exceptions import InvalidProject
 from rook import CONFIG
 
+TC_ALL_MONTHS = "month:jan,feb,mar,apr,may,jun,jul,aug,sep,oct,nov,dec"
+TC_ALL_MONTHS_2 = "month:01,02,03,04,05,06,07,08,09,10,11,12"
+TC_ALL_DAYS = "day:01,02,03,04,05,06,07,08,09,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"
+
 
 def fix_parameters(parameters):
     if "time_components" in parameters:
@@ -16,21 +20,17 @@ def fix_parameters(parameters):
 
 def fix_time_components(tc):
     # Remove redundant time-component parts to avoid for example issues with 360day calendars.
-    tc_all_months = "month:jan,feb,mar,apr,may,jun,jul,aug,sep,oct,nov,dec"
-    tc_all_months_2 = "month:01,02,03,04,05,06,07,08,09,10,11,12"
-    tc_all_days = "day:01,02,03,04,05,06,07,08,09,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"
-
     if not tc:
         return None
 
     tc_parts = tc.split("|")
     new_tc_parts = []
     for tc_part in tc_parts:
-        if tc_part == tc_all_months:
+        if tc_part == TC_ALL_MONTHS:
             continue
-        if tc_part == tc_all_months_2:
+        if tc_part == TC_ALL_MONTHS_2:
             continue
-        if tc_part == tc_all_days:
+        if tc_part == TC_ALL_DAYS:
             continue
         new_tc_parts.append(tc_part)
     new_tc = "|".join(new_tc_parts)

--- a/rook/utils/input_utils.py
+++ b/rook/utils/input_utils.py
@@ -6,6 +6,14 @@ from roocs_utils.exceptions import InvalidProject
 from rook import CONFIG
 
 
+def fix_parameters(parameters):
+    if "time_components" in parameters:
+        parameters["time_components"] = fix_time_components(
+            parameters["time_components"]
+        )
+    return parameters
+
+
 def fix_time_components(tc):
     # Remove redundant time-component parts to avoid for example issues with 360day calendars.
     tc_all_months = "month:jan,feb,mar,apr,may,jun,jul,aug,sep,oct,nov,dec"

--- a/rook/utils/subset_utils.py
+++ b/rook/utils/subset_utils.py
@@ -1,6 +1,11 @@
+from .input_utils import fix_parameters
+
+
 def run_subset(args):
     # TODO: handle lazy load of daops
     from daops.ops.subset import subset
+
+    args = fix_parameters(args)
 
     result = subset(**args)
     return result.file_uris

--- a/tests/smoke/test_smoke_checks.py
+++ b/tests/smoke/test_smoke_checks.py
@@ -1,4 +1,4 @@
-from pyparsing import dbl_slash_comment
+# from pyparsing import dbl_slash_comment
 from tests.smoke.utils import open_dataset
 
 from owslib.wps import ComplexDataInput
@@ -124,6 +124,29 @@ WF_C3S_CMIP6_REGRID = json.dumps(
     }
 )
 
+TC_ALL_DAYS = "day:01,02,03,04,05,06,07,08,09,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"
+
+WF_C3S_CMIP6_360DAY_CALENDAR = json.dumps(
+    {
+        "doc": "subset+average on cmip6",
+        "inputs": {"ds": [C3S_CMIP6_360DAY_CALENDAR_COLLECTION]},
+        "outputs": {"output": "average/output"},
+        "steps": {
+            "subset": {
+                "run": "subset",
+                "in": {
+                    "collection": "inputs/ds",
+                    "time": "2015/2015",
+                    "time_components": f"month:01,02,03|{TC_ALL_DAYS}",
+                },
+            },
+            "average": {
+                "run": "average",
+                "in": {"collection": "subset/output", "dims": "time"},
+            },
+        },
+    }
+)
 
 WF_C3S_CORDEX = json.dumps(
     {
@@ -557,6 +580,15 @@ def test_smoke_execute_c3s_cmip6_regrid_orchestrate(wps):
         "rlds_Amon_INM-CM5-0_ssp245_r1i1p1f1_gr_20160116-20161216_regrid-nearest_s2d-180x360_cells_grid.nc"
         in urls[0]
     )
+
+
+def test_smoke_execute_c3s_cmip6_360day_calendar_orchestrate(wps):
+    inputs = [
+        ("workflow", ComplexDataInput(WF_C3S_CMIP6_360DAY_CALENDAR)),
+    ]
+    urls = wps.execute("orchestrate", inputs)
+    assert len(urls) == 1
+    assert "pr_day_HadGEM3-GC31-LL_ssp245_r1i1p1f3_gn_20150101-20150330.nc" in urls[0]
 
 
 def test_smoke_execute_c3s_cmip6_orchestrate_metadata(wps, tmp_path):

--- a/tests/smoke/test_smoke_checks.py
+++ b/tests/smoke/test_smoke_checks.py
@@ -128,9 +128,9 @@ TC_ALL_DAYS = "day:01,02,03,04,05,06,07,08,09,10,11,12,13,14,15,16,17,18,19,20,2
 
 WF_C3S_CMIP6_360DAY_CALENDAR = json.dumps(
     {
-        "doc": "subset+average on cmip6",
+        "doc": "subset on cmip6",
         "inputs": {"ds": [C3S_CMIP6_360DAY_CALENDAR_COLLECTION]},
-        "outputs": {"output": "average/output"},
+        "outputs": {"output": "subset/output"},
         "steps": {
             "subset": {
                 "run": "subset",
@@ -139,10 +139,6 @@ WF_C3S_CMIP6_360DAY_CALENDAR = json.dumps(
                     "time": "2015/2015",
                     "time_components": f"month:01,02,03|{TC_ALL_DAYS}",
                 },
-            },
-            "average": {
-                "run": "average",
-                "in": {"collection": "subset/output", "dims": "time"},
             },
         },
     }

--- a/tests/smoke/test_smoke_checks.py
+++ b/tests/smoke/test_smoke_checks.py
@@ -371,11 +371,10 @@ def test_smoke_execute_c3s_cmip6_subset_by_point(wps, tmp_path):
 
 
 def test_smoke_execute_c3s_cmip6_360calendar_subset_by_point(wps, tmp_path):
-    all_days = "day:01,02,03,04,05,06,07,08,09,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"
     inputs = [
         ("collection", C3S_CMIP6_360DAY_CALENDAR_COLLECTION),
         ("time", "2015/2015"),
-        ("time_components", f"month:jan,feb,mar|{all_days}"),
+        ("time_components", f"month:jan,feb,mar|{TC_ALL_DAYS}"),
     ]
     urls = wps.execute("subset", inputs)
     assert len(urls) == 1

--- a/tests/smoke/test_smoke_checks.py
+++ b/tests/smoke/test_smoke_checks.py
@@ -26,6 +26,10 @@ C3S_CMIP6_MON_LEVEL_COLLECTION = (
     "c3s-cmip6.CMIP.CSIRO-ARCCSS.ACCESS-CM2.historical.r1i1p1f1.Amon.ta.gn.v20191108"
 )
 
+C3S_CMIP6_360DAY_CALENDAR_COLLECTION = (
+    "c3s-cmip6.ScenarioMIP.MOHC.HadGEM3-GC31-LL.ssp245.r1i1p1f3.day.pr.gn.v20190908"
+)
+
 C3S_CMIP5_DAY_COLLECTION = (
     "c3s-cmip5.output1.IPSL.IPSL-CM5B-LR.historical.day.atmos.day.r1i1p1.tas.v20120718"
 )
@@ -345,6 +349,20 @@ def test_smoke_execute_c3s_cmip6_subset_by_point(wps, tmp_path):
     assert "rlds_Amon_INM-CM5-0_ssp245_r1i1p1f1_gr1_20200116-20200316.nc" in urls[0]
     ds = open_dataset(urls[0], tmp_path)
     assert "rlds" in ds.variables
+
+
+def test_smoke_execute_c3s_cmip6_360calendar_subset_by_point(wps, tmp_path):
+    all_days = "day:01,02,03,04,05,06,07,08,09,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"
+    inputs = [
+        ("collection", C3S_CMIP6_360DAY_CALENDAR_COLLECTION),
+        ("time", "2015/2015"),
+        ("time_components", f"month:jan,feb,mar|{all_days}"),
+    ]
+    urls = wps.execute("subset", inputs)
+    assert len(urls) == 1
+    assert "pr_day_HadGEM3-GC31-LL_ssp245_r1i1p1f3_gn_20150101-20150330.nc" in urls[0]
+    ds = open_dataset(urls[0], tmp_path)
+    assert "pr" in ds.variables
 
 
 def test_smoke_execute_c3s_cordex_subset_by_point(wps, tmp_path):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,7 +3,11 @@ import pytest
 
 from pywps.app import WPSRequest
 
-from rook.utils.input_utils import resolve_to_file_paths, parse_wps_input
+from rook.utils.input_utils import (
+    resolve_to_file_paths,
+    parse_wps_input,
+    fix_time_components,
+)
 from rook.utils.metalink_utils import build_metalink
 
 from .common import TESTS_HOME, MINI_ESGF_MASTER_DIR
@@ -123,4 +127,28 @@ def test_parse_wps_input():
     assert (
         parse_wps_input(request.inputs, "time_components", default=None)
         == "year:1970,1980|month=01,02,03"
+    )
+
+
+def test_fix_time_components():
+    assert (
+        fix_time_components("year:2000|month=01|day=01") == "year:2000|month=01|day=01"
+    )
+
+    all_days = "day:01,02,03,04,05,06,07,08,09,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"
+    assert (
+        fix_time_components(f"year:2001,2002|month=02|{all_days}")
+        == "year:2001,2002|month=02"
+    )
+
+    all_months = "month:jan,feb,mar,apr,may,jun,jul,aug,sep,oct,nov,dec"
+    assert (
+        fix_time_components(f"year:2001,2002|{all_months}|{all_days}")
+        == "year:2001,2002"
+    )
+
+    all_months_2 = "month:01,02,03,04,05,06,07,08,09,10,11,12"
+    assert (
+        fix_time_components(f"year:2001,2002|{all_months_2}|day:01,31")
+        == "year:2001,2002|day:01,31"
     )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -152,3 +152,6 @@ def test_fix_time_components():
         fix_time_components(f"year:2001,2002|{all_months_2}|day:01,31")
         == "year:2001,2002|day:01,31"
     )
+
+    assert fix_time_components("") is None
+    assert fix_time_components(None) is None


### PR DESCRIPTION
## Overview

This PR fixes an issue with 360day calendars. It removes redundant parts from the `time_component` to avoid the selection of day 31. 

Changes:

* Added `fix_time_componets` in  `input_utils`.
* Use `fix_time_components` in subset and concat operator.
* Added tests.

## Related Issue / Discussion

## Additional Information

https://nbviewer.org/github/roocs/rooki/blob/master/notebooks/errors/cds-error-2023-12-05-360day-calendar.ipynb