### PR TITLE
Fix documentation links

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -3,4 +3,4 @@
 Contributions are welcome, and they are greatly appreciated! Every little bit helps, and credit will always be given.
 
 Please read the Birdhouse [Developer Guide](https://birdhouse.readthedocs.io/en/latest/dev_guide.html)
-and the [rook Documentation](https://rook.readthedocs.io/en/latest/) to get started.
+and the [rook Documentation](https://rook-wps.readthedocs.io/en/latest/) to get started.

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ rook
     :alt: Build Status
 
 .. image:: https://readthedocs.org/projects/rook/badge/?version=latest
-    :target: https://rook.readthedocs.io/en/latest/?version=latest
+    :target: https://rook-wps.readthedocs.io/en/latest/?version=latest
     :alt: Documentation Status
 
 .. image:: https://img.shields.io/github/license/roocs/rook.svg
@@ -31,7 +31,7 @@ available in the daops_ library based on xarray.
 Documentation
 -------------
 
-Learn more about rook in its official documentation at https://rook.readthedocs.io.
+Learn more about rook in its official documentation at https://rook-wps.readthedocs.io.
 
 Submit bug reports, questions and feature requests at https://github.com/roocs/rook/issues
 

--- a/src/rook/default.cfg
+++ b/src/rook/default.cfg
@@ -4,7 +4,7 @@ identification_abstract = Rook is a Web Processing Service (WPS) of the roocs pr
 identification_keywords = PyWPS, WPS, OGC, processing, birdhouse, roocs, copernicus
 identification_keywords_type = theme
 provider_name = rook
-provider_url=http://rook.readthedocs.org/en/latest/
+provider_url=http://rook-wps.readthedocs.org/en/latest/
 
 [server]
 url = http://localhost:5000/wps


### PR DESCRIPTION
## Overview

Some documentation links referred to https://rook.readthedocs.io (a different project: https://github.com/AvisoNovate/rook). The actual documentation is at https://rook-wps.readthedocs.io

Changes:

* Fixed documentation links

## Related Issue / Discussion

## Additional Information
