### PR TITLE
renamed branch master to main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,13 +3,13 @@ name: build ⚙️
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
 
 concurrency:
-  # For a given workflow, if we push to the same branch, cancel all previous builds on that branch except on master.
+  # For a given workflow, if we push to the same branch, cancel all previous builds on that branch except on main.
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ rook
     :alt: Documentation Status
 
 .. image:: https://img.shields.io/github/license/roocs/rook.svg
-    :target: https://github.com/roocs/rook/blob/master/LICENSE.txt
+    :target: https://github.com/roocs/rook/blob/main/LICENSE.txt
     :alt: GitHub license
 
 rook (the bird)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ rook = "rook.cli:cli"
 
 [project.urls]
 "Issue tracker" = "https://github.com/roocs/rook/issues"
-"Changelog" = "https://github.com/roocs/rook/blob/master/changelog.rst"
+"Changelog" = "https://github.com/roocs/rook/blob/main/changelog.rst"
 "Homepage" = "https://github.com/roocs/rook"
 
 [tool]


### PR DESCRIPTION
## Overview

This PR updates the configs and docs to use now the `main` branch instead of `master`.


## Related Issue / Discussion

## Additional Information

