### PR TITLE
Fix smoke tests

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -18,4 +18,3 @@ dependencies:
   - pytest >=8.0.0
   - pytest-cov >=5.0.0
   - pytest-timeout >=2.3.1
-  - beautifulsoup4 >4.12.3

--- a/environment.yml
+++ b/environment.yml
@@ -17,6 +17,7 @@ dependencies:
   - daops >=0.14.0
   - clisops >=0.15.0
   - roocs-grids >=0.1.2
+  - beautifulsoup4 >4.12.3
   # workflow
   - networkx
   # provenance

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,12 +49,12 @@ dependencies = [
   "aiohttp",
   "bokeh",
   "humanize",
+  "beautifulsoup4",
 ]
 
 [project.optional-dependencies]
 dev = [
   "pip >=24.2.0",
-  "beautifulsoup4",
   "black >=24.10.0",
   "bump-my-version >=0.26.0",
   "coverage >=7.5.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
   "aiohttp",
   "bokeh",
   "humanize",
-  "beautifulsoup4",
+  "beautifulsoup4 >4.12.3",
 ]
 
 [project.optional-dependencies]

--- a/src/rook/utils/decadal_fixes.py
+++ b/src/rook/utils/decadal_fixes.py
@@ -147,6 +147,6 @@ def decadal_fix_calendar(ds_id, ds, output_dir=None):
         tmp_dir = tempfile.TemporaryDirectory(dir=output_dir)
         fixed_nc = Path(tmp_dir.name) / "fixed_calendar.nc"
         ds.to_netcdf(fixed_nc)
-        ds = open_xr_dataset(fixed_nc)
+        ds = open_xr_dataset(fixed_nc.as_posix())
         tmp_dir.cleanup()
     return ds

--- a/src/rook/utils/metalink_utils.py
+++ b/src/rook/utils/metalink_utils.py
@@ -29,8 +29,13 @@ def build_metalink(identity, description, workdir, file_uris, file_type="NetCDF"
     return ml4
 
 
-def parse_metalink(path):
+def extract_paths_from_metalink(path):
     path = path.replace("file://", "")
-    doc = BeautifulSoup(Path(path).open().read(), "xml")
+    xml = Path(path).open().read()
+    return parse_metalink(xml)
+
+
+def parse_metalink(xml):
+    doc = BeautifulSoup(xml, "xml")
     paths = [el.text.replace("file://", "") for el in doc.find_all("metaurl")]
     return paths

--- a/src/rook/utils/metalink_utils.py
+++ b/src/rook/utils/metalink_utils.py
@@ -1,4 +1,7 @@
 from urllib.parse import urlparse
+from bs4 import BeautifulSoup
+from pathlib import Path
+
 
 from pywps import FORMATS
 from pywps.inout.outputs import MetaFile, MetaLink4
@@ -24,3 +27,10 @@ def build_metalink(identity, description, workdir, file_uris, file_type="NetCDF"
         ml4.append(mf)
 
     return ml4
+
+
+def parse_metalink(path):
+    path = path.replace("file://", "")
+    doc = BeautifulSoup(Path(path).open().read(), "xml")
+    paths = [el.text.replace("file://", "") for el in doc.find_all("metaurl")]
+    return paths

--- a/src/rook/workflow.py
+++ b/src/rook/workflow.py
@@ -19,8 +19,17 @@ from .provenance import Provenance
 LOGGER = logging.getLogger()
 
 
+def is_file(data):
+    try:
+        ok = Path(data).is_file()
+    except OSError as e:
+        LOGGER.warning(f"is_file check failed. reason={e}")
+        ok = False
+    return ok
+
+
 def load_wfdoc(data):
-    if Path(data).is_file():
+    if is_file(data):
         wfdoc = yaml.load(Path(data).open("rb"), Loader=yaml.SafeLoader)
     else:
         wfdoc = yaml.load(data, Loader=yaml.SafeLoader)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,7 @@ xpath_ns = get_xpath_ns(VERSION)
 
 TESTS_HOME = Path(__file__).parent.absolute()
 ROOCS_CFG = TESTS_HOME.joinpath(".roocs.ini")
+PYWPS_CFG = TESTS_HOME.joinpath("pywps.cfg")
 
 
 @pytest.fixture(scope="session")
@@ -83,6 +84,11 @@ def write_roocs_cfg(stratus):
     # rook.catalog.CONFIG = cfg
     # print("clisops.config", clisops.CONFIG["project:cmip5"]["base_dir"])
     # print("rook.config", rook.CONFIG["project:cmip6"]["base_dir"])
+
+
+@pytest.fixture
+def pywps_cfg():
+    return PYWPS_CFG
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -174,7 +174,7 @@ def download_file(url, tmp_path):
     # https://docs.pytest.org/en/stable/tmpdir.html
     local_filename = url.split("/")[-1]
     p = tmp_path / local_filename
-    with requests.get(url, stream=True) as r:
+    with requests.get(url, stream=True, timeout=30) as r:
         with p.open(mode="wb") as f:
             shutil.copyfileobj(r.raw, f)
     return p.as_posix()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,6 @@ import os
 from pathlib import Path
 
 import pytest
-from bs4 import BeautifulSoup
 from clisops.utils.testing import (
     ESGF_TEST_DATA_CACHE_DIR,
     ESGF_TEST_DATA_REPO_URL,
@@ -11,7 +10,6 @@ from clisops.utils.testing import (
 )
 from clisops.utils.testing import stratus as _stratus
 from jinja2 import Template
-from lxml import etree
 from pywps import get_ElementMakerForVersion
 from pywps.app.basic import get_xpath_ns
 from pywps.tests import WpsClient, WpsTestResponse
@@ -98,30 +96,6 @@ def resource_file():
 @pytest.fixture
 def fake_inv():
     os.environ["ROOK_FAKE_INVENTORY"] = "1"
-
-
-@pytest.fixture
-def extract_paths_from_metalink():
-
-    def _extract_paths_from_metalink(path):
-        path = path.replace("file://", "")
-        doc = BeautifulSoup(Path(path).open().read(), "xml")
-        paths = [el.text.replace("file://", "") for el in doc.find_all("metaurl")]
-        return paths
-
-    return _extract_paths_from_metalink
-
-
-@pytest.fixture
-def parse_metalink():
-
-    def _parse_metalink(xml):
-        xml_ = xml.replace(' xmlns="', ' xmlnamespace="')
-        tree = etree.fromstring(xml_.encode())  # noqa: S320
-        urls = [m.text for m in tree.xpath("//metaurl")]
-        return urls
-
-    return _parse_metalink
 
 
 class WpsTestClient(WpsClient):

--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -11,7 +11,7 @@ PYWPS_CFG = TESTS_HOME.joinpath("pywps.cfg")
 
 
 def server_url():
-    config.load_configuration(cfgfiles=PYWPS_CFG)
+    config.load_configuration(cfgfiles=PYWPS_CFG.as_posix())
     url = config.get_config_value("server", "url")
     return url
 

--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -2,9 +2,10 @@ from pathlib import Path
 
 import pytest
 import requests
-from lxml import etree
 from owslib.wps import WebProcessingService, monitorExecution
 from pywps import configuration as config
+
+from rook.utils.metalink_utils import parse_metalink
 
 TESTS_HOME = Path(__file__).parent.parent.absolute()
 PYWPS_CFG = TESTS_HOME.joinpath("pywps.cfg")
@@ -14,13 +15,6 @@ def server_url():
     config.load_configuration(cfgfiles=PYWPS_CFG.as_posix())
     url = config.get_config_value("server", "url")
     return url
-
-
-def parse_metalink(xml):
-    xml_ = xml.replace(' xmlns="', ' xmlnamespace="')
-    tree = etree.fromstring(xml_.encode())  # noqa: S320
-    urls = [m.text for m in tree.xpath("//metaurl")]
-    return urls
 
 
 class RookWPS:

--- a/tests/test_wps_average_dim.py
+++ b/tests/test_wps_average_dim.py
@@ -1,16 +1,11 @@
-from pathlib import Path
-
 from pywps import Service
 from pywps.tests import assert_process_exception, assert_response_success, client_for
 
 from rook.processes.wps_average_dim import AverageByDimension
 
-TESTS_HOME = Path(__file__).parent.absolute()
-PYWPS_CFG = TESTS_HOME.joinpath("pywps.cfg")
 
-
-def test_wps_average_time_cmip5(get_output):
-    client = client_for(Service(processes=[AverageByDimension()], cfgfiles=[PYWPS_CFG]))
+def test_wps_average_time_cmip5(get_output, pywps_cfg):
+    client = client_for(Service(processes=[AverageByDimension()], cfgfiles=[pywps_cfg]))
     datainputs = "collection=c3s-cmip5.output1.ICHEC.EC-EARTH.historical.day.atmos.day.r1i1p1.tas.v20131231"
     datainputs += ";dims=time"
     resp = client.get(
@@ -20,9 +15,9 @@ def test_wps_average_time_cmip5(get_output):
     assert "output" in get_output(resp.xml)
 
 
-def test_wps_average_time_cmip6(get_output):
+def test_wps_average_time_cmip6(get_output, pywps_cfg):
     # test the case where the inventory is used
-    client = client_for(Service(processes=[AverageByDimension()], cfgfiles=[PYWPS_CFG]))
+    client = client_for(Service(processes=[AverageByDimension()], cfgfiles=[pywps_cfg]))
     datainputs = "collection=c3s-cmip6.ScenarioMIP.INM.INM-CM5-0.ssp245.r1i1p1f1.Amon.rlds.gr1.v20190619"
     datainputs += ";dims=time"
     resp = client.get(
@@ -32,9 +27,9 @@ def test_wps_average_time_cmip6(get_output):
     assert "output" in get_output(resp.xml)
 
 
-def test_wps_average_latlon_cmip6(get_output):
+def test_wps_average_latlon_cmip6(get_output, pywps_cfg):
     # test the case where the inventory is used
-    client = client_for(Service(processes=[AverageByDimension()], cfgfiles=[PYWPS_CFG]))
+    client = client_for(Service(processes=[AverageByDimension()], cfgfiles=[pywps_cfg]))
     datainputs = "collection=c3s-cmip6.ScenarioMIP.INM.INM-CM5-0.ssp245.r1i1p1f1.Amon.rlds.gr1.v20190619"
     datainputs += ";dims=latitude;dims=longitude"
     resp = client.get(
@@ -44,8 +39,8 @@ def test_wps_average_latlon_cmip6(get_output):
     assert "output" in get_output(resp.xml)
 
 
-def test_wps_average_no_dim():
-    client = client_for(Service(processes=[AverageByDimension()], cfgfiles=[PYWPS_CFG]))
+def test_wps_average_no_dim(pywps_cfg):
+    client = client_for(Service(processes=[AverageByDimension()], cfgfiles=[pywps_cfg]))
     datainputs = "collection=c3s-cmip6.ScenarioMIP.INM.INM-CM5-0.ssp245.r1i1p1f1.Amon.rlds.gr1.v20190619"
     resp = client.get(
         f"?service=WPS&request=Execute&version=1.0.0&identifier=average&datainputs={datainputs}"

--- a/tests/test_wps_average_shape.py
+++ b/tests/test_wps_average_shape.py
@@ -5,6 +5,7 @@ import xarray as xr
 from pywps import Service
 from pywps.tests import assert_process_exception, assert_response_success, client_for
 from shapely import Polygon
+from rook.utils.metalink_utils import parse_metalink
 
 from rook.processes.wps_average_shape import AverageByShape
 
@@ -24,7 +25,7 @@ POLY = Polygon(
 )
 
 
-def test_wps_average_shape_cmip6(tmp_path, get_output, extract_paths_from_metalink):
+def test_wps_average_shape_cmip6(tmp_path, get_output):
     # Save POLY to tmpdir
     tmp_poly_path = tmp_path / "tmppoly.json"
     gpd.GeoDataFrame([{"geometry": POLY}]).to_file(tmp_poly_path.as_posix())
@@ -38,12 +39,12 @@ def test_wps_average_shape_cmip6(tmp_path, get_output, extract_paths_from_metali
     )
     assert_response_success(resp)
     assert "output" in get_output(resp.xml)
-    assert_geom_created(get_output(resp.xml)["output"], extract_paths_from_metalink)
+    assert_geom_created(get_output(resp.xml)["output"])
 
 
-def assert_geom_created(path, extract_paths_from_metalink):
+def assert_geom_created(path):
     assert "meta4" in path
-    paths = extract_paths_from_metalink(path)
+    paths = parse_metalink(path)
     assert len(paths) > 0
     ds = xr.open_dataset(paths[0])
     assert "geom" in ds.coords

--- a/tests/test_wps_average_shape.py
+++ b/tests/test_wps_average_shape.py
@@ -3,7 +3,7 @@ import xarray as xr
 from pywps import Service
 from pywps.tests import assert_process_exception, assert_response_success, client_for
 from shapely import Polygon
-from rook.utils.metalink_utils import parse_metalink
+from rook.utils.metalink_utils import extract_paths_from_metalink
 
 from rook.processes.wps_average_shape import AverageByShape
 
@@ -40,7 +40,7 @@ def test_wps_average_shape_cmip6(tmp_path, get_output, pywps_cfg):
 
 def assert_geom_created(path):
     assert "meta4" in path
-    paths = parse_metalink(path)
+    paths = extract_paths_from_metalink(path)
     assert len(paths) > 0
     ds = xr.open_dataset(paths[0])
     assert "geom" in ds.coords

--- a/tests/test_wps_average_shape.py
+++ b/tests/test_wps_average_shape.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-
 import geopandas as gpd
 import xarray as xr
 from pywps import Service
@@ -9,8 +7,6 @@ from rook.utils.metalink_utils import parse_metalink
 
 from rook.processes.wps_average_shape import AverageByShape
 
-TESTS_HOME = Path(__file__).parent.absolute()
-PYWPS_CFG = TESTS_HOME.joinpath("pywps.cfg")
 
 POLY = Polygon(
     [
@@ -25,13 +21,13 @@ POLY = Polygon(
 )
 
 
-def test_wps_average_shape_cmip6(tmp_path, get_output):
+def test_wps_average_shape_cmip6(tmp_path, get_output, pywps_cfg):
     # Save POLY to tmpdir
     tmp_poly_path = tmp_path / "tmppoly.json"
     gpd.GeoDataFrame([{"geometry": POLY}]).to_file(tmp_poly_path.as_posix())
 
     # test the case where the inventory is used
-    client = client_for(Service(processes=[AverageByShape()], cfgfiles=[PYWPS_CFG]))
+    client = client_for(Service(processes=[AverageByShape()], cfgfiles=[pywps_cfg]))
     datainputs = "collection=c3s-cmip6.ScenarioMIP.INM.INM-CM5-0.ssp245.r1i1p1f1.Amon.rlds.gr1.v20190619"
     datainputs += f";shape={tmp_poly_path}"
     resp = client.get(
@@ -50,8 +46,8 @@ def assert_geom_created(path):
     assert "geom" in ds.coords
 
 
-def test_wps_average_no_shape():
-    client = client_for(Service(processes=[AverageByShape()], cfgfiles=[PYWPS_CFG]))
+def test_wps_average_no_shape(pywps_cfg):
+    client = client_for(Service(processes=[AverageByShape()], cfgfiles=[pywps_cfg]))
     datainputs = "collection=c3s-cmip6.ScenarioMIP.INM.INM-CM5-0.ssp245.r1i1p1f1.Amon.rlds.gr1.v20190619"
     resp = client.get(
         f"?service=WPS&request=Execute&version=1.0.0&identifier=average_shape&datainputs={datainputs}"

--- a/tests/test_wps_average_time.py
+++ b/tests/test_wps_average_time.py
@@ -1,16 +1,11 @@
-from pathlib import Path
-
 from pywps import Service
 from pywps.tests import assert_process_exception, assert_response_success, client_for
 
 from rook.processes.wps_average_time import AverageByTime
 
-TESTS_HOME = Path(__file__).parent.absolute()
-PYWPS_CFG = TESTS_HOME.joinpath("pywps.cfg")
 
-
-def test_wps_average_year_cmip5(get_output):
-    client = client_for(Service(processes=[AverageByTime()], cfgfiles=[PYWPS_CFG]))
+def test_wps_average_year_cmip5(get_output, pywps_cfg):
+    client = client_for(Service(processes=[AverageByTime()], cfgfiles=[pywps_cfg]))
     datainputs = "collection=c3s-cmip5.output1.ICHEC.EC-EARTH.historical.day.atmos.day.r1i1p1.tas.v20131231"
     datainputs += ";freq=year"
     resp = client.get(
@@ -20,9 +15,9 @@ def test_wps_average_year_cmip5(get_output):
     assert "output" in get_output(resp.xml)
 
 
-def test_wps_average_year_cmip6(get_output):
+def test_wps_average_year_cmip6(get_output, pywps_cfg):
     # test the case where the inventory is used
-    client = client_for(Service(processes=[AverageByTime()], cfgfiles=[PYWPS_CFG]))
+    client = client_for(Service(processes=[AverageByTime()], cfgfiles=[pywps_cfg]))
     datainputs = "collection=c3s-cmip6.ScenarioMIP.INM.INM-CM5-0.ssp245.r1i1p1f1.Amon.rlds.gr1.v20190619"
     datainputs += ";freq=year"
     resp = client.get(
@@ -32,8 +27,8 @@ def test_wps_average_year_cmip6(get_output):
     assert "output" in get_output(resp.xml)
 
 
-def test_wps_average_no_freq():
-    client = client_for(Service(processes=[AverageByTime()], cfgfiles=[PYWPS_CFG]))
+def test_wps_average_no_freq(pywps_cfg):
+    client = client_for(Service(processes=[AverageByTime()], cfgfiles=[pywps_cfg]))
     datainputs = "collection=c3s-cmip6.ScenarioMIP.INM.INM-CM5-0.ssp245.r1i1p1f1.Amon.rlds.gr1.v20190619"
     resp = client.get(
         f"?service=WPS&request=Execute&version=1.0.0&identifier=average_time&datainputs={datainputs}"

--- a/tests/test_wps_average_weighted.py
+++ b/tests/test_wps_average_weighted.py
@@ -3,12 +3,12 @@ from pywps import Service
 from pywps.tests import assert_response_success, client_for
 
 from rook.processes.wps_average_weighted import WeightedAverage
-from rook.utils.metalink_utils import parse_metalink
+from rook.utils.metalink_utils import extract_paths_from_metalink
 
 
 def assert_weighted_average(path):
     assert "meta4" in path
-    paths = parse_metalink(path)
+    paths = extract_paths_from_metalink(path)
     assert len(paths) > 0
     print(paths)
     ds = xr.open_dataset(paths[0])

--- a/tests/test_wps_average_weighted.py
+++ b/tests/test_wps_average_weighted.py
@@ -5,21 +5,22 @@ from pywps import Service
 from pywps.tests import assert_response_success, client_for
 
 from rook.processes.wps_average_weighted import WeightedAverage
+from rook.utils.metalink_utils import parse_metalink
 
 TESTS_HOME = Path(__file__).parent.absolute()
 PYWPS_CFG = TESTS_HOME.joinpath("pywps.cfg")
 
 
-def assert_weighted_average(path, extract_paths_from_metalink):
+def assert_weighted_average(path):
     assert "meta4" in path
-    paths = extract_paths_from_metalink(path)
+    paths = parse_metalink(path)
     assert len(paths) > 0
     print(paths)
     ds = xr.open_dataset(paths[0])
     assert "time" in ds.coords
 
 
-def test_wps_weighted_average_cmip6(get_output, extract_paths_from_metalink):
+def test_wps_weighted_average_cmip6(get_output):
     # test the case where the inventory is used
     client = client_for(Service(processes=[WeightedAverage()], cfgfiles=[PYWPS_CFG]))
     datainputs = "collection=c3s-cmip6.ScenarioMIP.INM.INM-CM5-0.ssp245.r1i1p1f1.Amon.rlds.gr1.v20190619"
@@ -28,4 +29,4 @@ def test_wps_weighted_average_cmip6(get_output, extract_paths_from_metalink):
     )
     assert_response_success(resp)
     assert "output" in get_output(resp.xml)
-    assert_weighted_average(get_output(resp.xml)["output"], extract_paths_from_metalink)
+    assert_weighted_average(get_output(resp.xml)["output"])

--- a/tests/test_wps_average_weighted.py
+++ b/tests/test_wps_average_weighted.py
@@ -1,14 +1,9 @@
-from pathlib import Path
-
 import xarray as xr
 from pywps import Service
 from pywps.tests import assert_response_success, client_for
 
 from rook.processes.wps_average_weighted import WeightedAverage
 from rook.utils.metalink_utils import parse_metalink
-
-TESTS_HOME = Path(__file__).parent.absolute()
-PYWPS_CFG = TESTS_HOME.joinpath("pywps.cfg")
 
 
 def assert_weighted_average(path):
@@ -20,9 +15,9 @@ def assert_weighted_average(path):
     assert "time" in ds.coords
 
 
-def test_wps_weighted_average_cmip6(get_output):
+def test_wps_weighted_average_cmip6(get_output, pywps_cfg):
     # test the case where the inventory is used
-    client = client_for(Service(processes=[WeightedAverage()], cfgfiles=[PYWPS_CFG]))
+    client = client_for(Service(processes=[WeightedAverage()], cfgfiles=[pywps_cfg]))
     datainputs = "collection=c3s-cmip6.ScenarioMIP.INM.INM-CM5-0.ssp245.r1i1p1f1.Amon.rlds.gr1.v20190619"
     resp = client.get(
         f"?service=WPS&request=Execute&version=1.0.0&identifier=weighted_average&datainputs={datainputs}"

--- a/tests/test_wps_cmip6_decadal.py
+++ b/tests/test_wps_cmip6_decadal.py
@@ -6,14 +6,12 @@ from pywps import Service
 from pywps.tests import assert_response_success, client_for
 
 from rook.processes.wps_subset import Subset
-
-TESTS_HOME = Path(__file__).parent.absolute()
-PYWPS_CFG = TESTS_HOME.joinpath("pywps.cfg")
+from rook.utils.metalink_utils import parse_metalink
 
 
-def assert_decadal_fix_applied(path, extract_paths_from_metalink):
+def assert_decadal_fix_applied(path):
     assert "meta4" in path
-    paths = extract_paths_from_metalink(path)
+    paths = parse_metalink(path)
     assert len(paths) > 0
     ds = xr.open_dataset(paths[0])
     assert "reftime" in ds.coords
@@ -23,8 +21,8 @@ def assert_decadal_fix_applied(path, extract_paths_from_metalink):
 
 
 @pytest.mark.xfail(reason="c3s-cmip6 decdal not in catalog")
-def test_wps_subset_c3s_cmip6_decadal(get_output, extract_paths_from_metalink):
-    client = client_for(Service(processes=[Subset()], cfgfiles=[PYWPS_CFG]))
+def test_wps_subset_c3s_cmip6_decadal(get_output, pywps_cfg):
+    client = client_for(Service(processes=[Subset()], cfgfiles=[pywps_cfg]))
     collection = "c3s-cmip6.DCPP.MOHC.HadGEM3-GC31-MM.dcppA-hindcast.s2004-r3i1p1f2.Amon.pr.gn.v20200417"
     datainputs = f"collection={collection}"
     # datainputs += ";time=1960-01-01/1961-01-01"
@@ -32,6 +30,4 @@ def test_wps_subset_c3s_cmip6_decadal(get_output, extract_paths_from_metalink):
         f"?service=WPS&request=Execute&version=1.0.0&identifier=subset&datainputs={datainputs}"
     )
     assert_response_success(resp)
-    assert_decadal_fix_applied(
-        get_output(resp.xml)["output"], extract_paths_from_metalink
-    )
+    assert_decadal_fix_applied(get_output(resp.xml)["output"])

--- a/tests/test_wps_cmip6_decadal.py
+++ b/tests/test_wps_cmip6_decadal.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-
 import pytest
 import xarray as xr
 from pywps import Service

--- a/tests/test_wps_cmip6_decadal.py
+++ b/tests/test_wps_cmip6_decadal.py
@@ -6,12 +6,12 @@ from pywps import Service
 from pywps.tests import assert_response_success, client_for
 
 from rook.processes.wps_subset import Subset
-from rook.utils.metalink_utils import parse_metalink
+from rook.utils.metalink_utils import extract_paths_from_metalink
 
 
 def assert_decadal_fix_applied(path):
     assert "meta4" in path
-    paths = parse_metalink(path)
+    paths = extract_paths_from_metalink(path)
     assert len(paths) > 0
     ds = xr.open_dataset(paths[0])
     assert "reftime" in ds.coords

--- a/tests/test_wps_concat.py
+++ b/tests/test_wps_concat.py
@@ -1,18 +1,13 @@
-from pathlib import Path
-
 import pytest
 from pywps import Service
 from pywps.tests import assert_response_success, client_for
 
 from rook.processes.wps_concat import Concat
 
-TESTS_HOME = Path(__file__).parent.absolute()
-PYWPS_CFG = TESTS_HOME.joinpath("pywps.cfg")
-
 
 @pytest.mark.xfail(reason="c3s-cmip6 decdal not in catalog")
-def test_wps_concat_ec_earth(get_output):
-    client = client_for(Service(processes=[Concat()], cfgfiles=[PYWPS_CFG]))
+def test_wps_concat_ec_earth(get_output, pywps_cfg):
+    client = client_for(Service(processes=[Concat()], cfgfiles=[pywps_cfg]))
     datainputs = "collection=c3s-cmip6.DCPP.EC-Earth-Consortium.EC-Earth3.dcppA-hindcast.s1960-r2i1p1f1.Amon.tas.gr.v20201215"  # noqa
     datainputs += ";collection=c3s-cmip6.DCPP.EC-Earth-Consortium.EC-Earth3.dcppA-hindcast.s1960-r6i2p1f1.Amon.tas.gr.v20200508"  # noqa
     datainputs += ";dims=realization"

--- a/tests/test_wps_orchestrate.py
+++ b/tests/test_wps_orchestrate.py
@@ -7,6 +7,7 @@ from pywps import Service
 from pywps.tests import assert_response_success, client_for
 
 from rook.processes.wps_orchestrate import Orchestrate
+from rook.utils.metalink_utils import parse_metalink
 
 TESTS_HOME = Path(__file__).parent.absolute()
 PYWPS_CFG = TESTS_HOME.joinpath("pywps.cfg")
@@ -92,9 +93,7 @@ def test_wps_orchestrate_average_latlon_cmip6(resource_file, get_output):
 
 
 @pytest.mark.xfail(reason="no cmip6 data in /pool/data")
-def test_wps_orchestrate_c3s_cmip6_subset_metadata(
-    resource_file, get_output, parse_metalink
-):
+def test_wps_orchestrate_c3s_cmip6_subset_metadata(resource_file, get_output):
     client = client_for(Service(processes=[Orchestrate()], cfgfiles=[PYWPS_CFG]))
     datainputs = "workflow=@xlink:href=file://{}".format(
         resource_file("wf_c3s_cmip6_subset.json")

--- a/tests/test_wps_orchestrate.py
+++ b/tests/test_wps_orchestrate.py
@@ -9,12 +9,9 @@ from pywps.tests import assert_response_success, client_for
 from rook.processes.wps_orchestrate import Orchestrate
 from rook.utils.metalink_utils import parse_metalink
 
-TESTS_HOME = Path(__file__).parent.absolute()
-PYWPS_CFG = TESTS_HOME.joinpath("pywps.cfg")
 
-
-def test_wps_orchestrate(resource_file, get_output):
-    client = client_for(Service(processes=[Orchestrate()], cfgfiles=[PYWPS_CFG]))
+def test_wps_orchestrate(resource_file, get_output, pywps_cfg):
+    client = client_for(Service(processes=[Orchestrate()], cfgfiles=[pywps_cfg]))
     datainputs = "workflow=@xlink:href=file://{}".format(
         resource_file("wf_cmip6_subset_average.json")
     )
@@ -25,9 +22,9 @@ def test_wps_orchestrate(resource_file, get_output):
     assert "meta4" in get_output(resp.xml)["output"]
 
 
-def test_wps_orchestrate_subset_collection_only(resource_file, get_output):
+def test_wps_orchestrate_subset_collection_only(resource_file, get_output, pywps_cfg):
     # TODO: this test is slow (25secs) ... but should be fast (1sec)
-    client = client_for(Service(processes=[Orchestrate()], cfgfiles=[PYWPS_CFG]))
+    client = client_for(Service(processes=[Orchestrate()], cfgfiles=[pywps_cfg]))
     datainputs = "workflow=@xlink:href=file://{}".format(
         resource_file("wf_c3s_cmip6_subset_collection_only.json")
     )
@@ -39,8 +36,8 @@ def test_wps_orchestrate_subset_collection_only(resource_file, get_output):
     assert "meta4" in get_output(resp.xml)["output"]
 
 
-def test_wps_orchestrate_prov(resource_file, get_output):
-    client = client_for(Service(processes=[Orchestrate()], cfgfiles=[PYWPS_CFG]))
+def test_wps_orchestrate_prov(resource_file, get_output, pywps_cfg):
+    client = client_for(Service(processes=[Orchestrate()], cfgfiles=[pywps_cfg]))
     datainputs = "workflow=@xlink:href=file://{}".format(
         resource_file("wf_cmip6_subset_average.json")
     )
@@ -62,8 +59,8 @@ def test_wps_orchestrate_prov(resource_file, get_output):
     )
 
 
-def test_wps_orchestrate_prov_with_fixes(resource_file, get_output):
-    client = client_for(Service(processes=[Orchestrate()], cfgfiles=[PYWPS_CFG]))
+def test_wps_orchestrate_prov_with_fixes(resource_file, get_output, pywps_cfg):
+    client = client_for(Service(processes=[Orchestrate()], cfgfiles=[pywps_cfg]))
     datainputs = "workflow=@xlink:href=file://{}".format(
         resource_file("wf_cmip6_subset_average_with_fixes.json")
     )
@@ -77,8 +74,8 @@ def test_wps_orchestrate_prov_with_fixes(resource_file, get_output):
     assert 'freq="year"' in doc.get_provn()
 
 
-def test_wps_orchestrate_average_latlon_cmip6(resource_file, get_output):
-    client = client_for(Service(processes=[Orchestrate()], cfgfiles=[PYWPS_CFG]))
+def test_wps_orchestrate_average_latlon_cmip6(resource_file, get_output, pywps_cfg):
+    client = client_for(Service(processes=[Orchestrate()], cfgfiles=[pywps_cfg]))
     datainputs = "workflow=@xlink:href=file://{}".format(
         resource_file("wf_average_latlon_cmip6.json")
     )
@@ -93,8 +90,10 @@ def test_wps_orchestrate_average_latlon_cmip6(resource_file, get_output):
 
 
 @pytest.mark.xfail(reason="no cmip6 data in /pool/data")
-def test_wps_orchestrate_c3s_cmip6_subset_metadata(resource_file, get_output):
-    client = client_for(Service(processes=[Orchestrate()], cfgfiles=[PYWPS_CFG]))
+def test_wps_orchestrate_c3s_cmip6_subset_metadata(
+    resource_file, get_output, pywps_cfg
+):
+    client = client_for(Service(processes=[Orchestrate()], cfgfiles=[pywps_cfg]))
     datainputs = "workflow=@xlink:href=file://{}".format(
         resource_file("wf_c3s_cmip6_subset.json")
     )

--- a/tests/test_wps_regrid.py
+++ b/tests/test_wps_regrid.py
@@ -6,17 +6,18 @@ from pywps import Service
 from pywps.tests import assert_response_success, client_for
 
 from rook.processes.wps_regrid import Regrid
+from rook.utils.metalink_utils import parse_metalink
 
 TESTS_HOME = Path(__file__).parent.absolute()
 PYWPS_CFG = TESTS_HOME.joinpath("pywps.cfg")
 
 
 @pytest.fixture
-def assert_regrid(extract_paths_from_metalink):
+def assert_regrid():
 
     def _assert_regrid(path):
         assert "meta4" in path
-        paths = extract_paths_from_metalink(path)
+        paths = parse_metalink(path)
         assert len(paths) > 0
         ds = xr.open_dataset(paths[0])
         assert "time" in ds.coords

--- a/tests/test_wps_regrid.py
+++ b/tests/test_wps_regrid.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-
 import pytest
 import xarray as xr
 from pywps import Service
@@ -7,9 +5,6 @@ from pywps.tests import assert_response_success, client_for
 
 from rook.processes.wps_regrid import Regrid
 from rook.utils.metalink_utils import parse_metalink
-
-TESTS_HOME = Path(__file__).parent.absolute()
-PYWPS_CFG = TESTS_HOME.joinpath("pywps.cfg")
 
 
 @pytest.fixture
@@ -25,8 +20,8 @@ def assert_regrid():
     return _assert_regrid
 
 
-def test_wps_regrid_cmip6(assert_regrid, get_output):
-    client = client_for(Service(processes=[Regrid()], cfgfiles=[PYWPS_CFG]))
+def test_wps_regrid_cmip6(assert_regrid, get_output, pywps_cfg):
+    client = client_for(Service(processes=[Regrid()], cfgfiles=[pywps_cfg]))
     datainputs = "collection=CMIP6.CMIP.IPSL.IPSL-CM6A-LR.historical.r1i1p1f1.Amon.rlds.gr.v20180803"
     datainputs += ";method=nearest_s2d"
     datainputs += ";grid=auto"

--- a/tests/test_wps_regrid.py
+++ b/tests/test_wps_regrid.py
@@ -4,7 +4,7 @@ from pywps import Service
 from pywps.tests import assert_response_success, client_for
 
 from rook.processes.wps_regrid import Regrid
-from rook.utils.metalink_utils import parse_metalink
+from rook.utils.metalink_utils import extract_paths_from_metalink
 
 
 @pytest.fixture
@@ -12,7 +12,7 @@ def assert_regrid():
 
     def _assert_regrid(path):
         assert "meta4" in path
-        paths = parse_metalink(path)
+        paths = extract_paths_from_metalink(path)
         assert len(paths) > 0
         ds = xr.open_dataset(paths[0])
         assert "time" in ds.coords

--- a/tests/test_wps_subset.py
+++ b/tests/test_wps_subset.py
@@ -9,9 +9,6 @@ from pywps.tests import assert_process_exception, assert_response_success, clien
 from rook.processes.wps_subset import Subset
 from rook.utils.metalink_utils import parse_metalink
 
-TESTS_HOME = Path(__file__).parent.absolute()
-PYWPS_CFG = TESTS_HOME.joinpath("pywps.cfg")
-
 
 C3S_CMIP6_MON_COLLECTION = (
     "c3s-cmip6.ScenarioMIP.INM.INM-CM5-0.ssp245.r1i1p1f1.Amon.rlds.gr1.v20190619"
@@ -28,8 +25,8 @@ C3S_ATLAS_V1_ERA5_COLLECTION = "c3s-cica-atlas.psl.ERA5.mon.v1"
 C3S_ATLAS_V1_CORDEX_COLLECTION = "c3s-cica-atlas.huss.CORDEX-CORE.historical.mon.v1"
 
 
-def test_wps_subset_cmip6_no_inv():
-    client = client_for(Service(processes=[Subset()], cfgfiles=[PYWPS_CFG]))
+def test_wps_subset_cmip6_no_inv(pywps_cfg):
+    client = client_for(Service(processes=[Subset()], cfgfiles=[pywps_cfg]))
     datainputs = "collection=c3s-cmip6.CMIP.MPI-M.MPI-ESM1-2-HR.historical.r1i1p1f1.SImon.siconc.gn.latest"
     datainputs += ";time=1860-01-01/1900-12-30"
     resp = client.get(
@@ -41,8 +38,8 @@ def test_wps_subset_cmip6_no_inv():
     )
 
 
-def test_wps_subset_c3s_cmip6(get_output):
-    client = client_for(Service(processes=[Subset()], cfgfiles=[PYWPS_CFG]))
+def test_wps_subset_c3s_cmip6(get_output, pywps_cfg):
+    client = client_for(Service(processes=[Subset()], cfgfiles=[pywps_cfg]))
     datainputs = f"collection={C3S_CMIP6_MON_COLLECTION}"
     datainputs += ";time=2015-01-01/2015-12-30;area=1,1,300,89"
     resp = client.get(
@@ -53,8 +50,8 @@ def test_wps_subset_c3s_cmip6(get_output):
 
 
 @pytest.mark.xfail(reason="no cmip6 data in /pool/data")
-def test_wps_subset_c3s_cmip6_time_series(get_output):
-    client = client_for(Service(processes=[Subset()], cfgfiles=[PYWPS_CFG]))
+def test_wps_subset_c3s_cmip6_time_series(get_output, pywps_cfg):
+    client = client_for(Service(processes=[Subset()], cfgfiles=[pywps_cfg]))
     datainputs = f"collection={C3S_CMIP6_MON_COLLECTION}"
     datainputs += ";time=2015-01-16T12:00:00,2016-01-16T12:00:00"
     resp = client.get(
@@ -64,8 +61,8 @@ def test_wps_subset_c3s_cmip6_time_series(get_output):
     assert "meta4" in get_output(resp.xml)["output"]
 
 
-def test_wps_subset_c3s_cmip6_time_components(get_output):
-    client = client_for(Service(processes=[Subset()], cfgfiles=[PYWPS_CFG]))
+def test_wps_subset_c3s_cmip6_time_components(get_output, pywps_cfg):
+    client = client_for(Service(processes=[Subset()], cfgfiles=[pywps_cfg]))
     datainputs = f"collection={C3S_CMIP6_MON_COLLECTION}"
     # datainputs += ";time=2015/2016"
     datainputs += ";time_components=year:2015,2016|month:01,02,03"
@@ -79,8 +76,8 @@ def test_wps_subset_c3s_cmip6_time_components(get_output):
 
 
 @pytest.mark.xfail(reason="no cmip6 data in /pool/data")
-def test_wps_subset_c3s_cmip6_metadata(get_output):
-    client = client_for(Service(processes=[Subset()], cfgfiles=[PYWPS_CFG]))
+def test_wps_subset_c3s_cmip6_metadata(get_output, pywps_cfg):
+    client = client_for(Service(processes=[Subset()], cfgfiles=[pywps_cfg]))
     datainputs = f"collection={C3S_CMIP6_MON_TASMIN_COLLECTION}"
     datainputs += ";time=2010/2010"
     resp = client.get(
@@ -110,8 +107,8 @@ def test_wps_subset_c3s_cmip6_metadata(get_output):
     assert "coordinates" not in ds.time_bnds.encoding
 
 
-def test_wps_subset_cmip6_prov(get_output):
-    client = client_for(Service(processes=[Subset()], cfgfiles=[PYWPS_CFG]))
+def test_wps_subset_cmip6_prov(get_output, pywps_cfg):
+    client = client_for(Service(processes=[Subset()], cfgfiles=[pywps_cfg]))
     datainputs = "collection=CMIP6.CMIP.IPSL.IPSL-CM6A-LR.historical.r1i1p1f1.Amon.rlds.gr.v20180803"
     datainputs += ";time=1860-01-01/1900-12-30;area=1,1,300,89"
     resp = client.get(
@@ -128,8 +125,8 @@ def test_wps_subset_cmip6_prov(get_output):
     )
 
 
-def test_wps_subset_cmip6_multiple_files_prov(get_output):
-    client = client_for(Service(processes=[Subset()], cfgfiles=[PYWPS_CFG]))
+def test_wps_subset_cmip6_multiple_files_prov(get_output, pywps_cfg):
+    client = client_for(Service(processes=[Subset()], cfgfiles=[pywps_cfg]))
     datainputs = "collection=CMIP6.CMIP.MPI-M.MPI-ESM1-2-HR.historical.r1i1p1f1.SImon.siconc.gn.latest"
     datainputs += ";time=1850-01-01/2013-12-30"
     resp = client.get(
@@ -145,8 +142,8 @@ def test_wps_subset_cmip6_multiple_files_prov(get_output):
     )
 
 
-def test_wps_subset_cmip6_original_files(get_output):
-    client = client_for(Service(processes=[Subset()], cfgfiles=[PYWPS_CFG]))
+def test_wps_subset_cmip6_original_files(get_output, pywps_cfg):
+    client = client_for(Service(processes=[Subset()], cfgfiles=[pywps_cfg]))
     datainputs = "collection=CMIP6.CMIP.IPSL.IPSL-CM6A-LR.historical.r1i1p1f1.Amon.rlds.gr.v20180803"
     datainputs += ";time=1860-01-01/1900-12-30;original_files=1"
     resp = client.get(
@@ -156,8 +153,8 @@ def test_wps_subset_cmip6_original_files(get_output):
     assert "meta4" in get_output(resp.xml)["output"]
 
 
-def test_wps_subset_c3s_cmip6_collection_only(get_output):
-    client = client_for(Service(processes=[Subset()], cfgfiles=[PYWPS_CFG]))
+def test_wps_subset_c3s_cmip6_collection_only(get_output, pywps_cfg):
+    client = client_for(Service(processes=[Subset()], cfgfiles=[pywps_cfg]))
     datainputs = f"collection={C3S_CMIP6_MON_COLLECTION}"
     resp = client.get(
         f"?service=WPS&request=Execute&version=1.0.0&identifier=subset&datainputs={datainputs}"
@@ -166,8 +163,8 @@ def test_wps_subset_c3s_cmip6_collection_only(get_output):
     assert "meta4" in get_output(resp.xml)["output"]
 
 
-def test_wps_subset_missing_collection():
-    client = client_for(Service(processes=[Subset()], cfgfiles=[PYWPS_CFG]))
+def test_wps_subset_missing_collection(pywps_cfg):
+    client = client_for(Service(processes=[Subset()], cfgfiles=[pywps_cfg]))
     datainputs = ""
     resp = client.get(
         f"?service=WPS&request=Execute&version=1.0.0&identifier=subset&datainputs={datainputs}"
@@ -176,8 +173,8 @@ def test_wps_subset_missing_collection():
 
 
 @pytest.mark.skip(reason="need a new test dataset")
-def test_wps_subset_time_invariant_dataset(get_output):
-    client = client_for(Service(processes=[Subset()], cfgfiles=[PYWPS_CFG]))
+def test_wps_subset_time_invariant_dataset(get_output, pywps_cfg):
+    client = client_for(Service(processes=[Subset()], cfgfiles=[pywps_cfg]))
     datainputs = "collection=c3s-cmip6.ScenarioMIP.IPSL.IPSL-CM6A-LR.ssp119.r1i1p1f1.fx.mrsofc.gr.v20190410"
     datainputs += ";area=1,1,300,89"
     resp = client.get(
@@ -187,8 +184,8 @@ def test_wps_subset_time_invariant_dataset(get_output):
     assert "meta4" in get_output(resp.xml)["output"]
 
 
-def test_wps_subset_c3s_atlas_v1_cmip5(get_output):
-    client = client_for(Service(processes=[Subset()], cfgfiles=[PYWPS_CFG]))
+def test_wps_subset_c3s_atlas_v1_cmip5(get_output, pywps_cfg):
+    client = client_for(Service(processes=[Subset()], cfgfiles=[pywps_cfg]))
     datainputs = f"collection={C3S_ATLAS_V1_CMIP5_COLLECTION}"
     datainputs += ";time=2020/2020"
     datainputs += ";time_components=month:jan,feb,mar"
@@ -203,8 +200,8 @@ def test_wps_subset_c3s_atlas_v1_cmip5(get_output):
     assert "roocs:pr_CMIP5_rcp26_mon_20200101-20200301.nc" in doc.get_provn()
 
 
-def test_wps_subset_c3s_atlas_v1_era5(get_output):
-    client = client_for(Service(processes=[Subset()], cfgfiles=[PYWPS_CFG]))
+def test_wps_subset_c3s_atlas_v1_era5(get_output, pywps_cfg):
+    client = client_for(Service(processes=[Subset()], cfgfiles=[pywps_cfg]))
     datainputs = f"collection={C3S_ATLAS_V1_ERA5_COLLECTION}"
     datainputs += ";time=2020/2020"
     datainputs += ";time_components=month:jan,feb,mar"

--- a/tests/test_wps_subset.py
+++ b/tests/test_wps_subset.py
@@ -7,6 +7,7 @@ from pywps import Service
 from pywps.tests import assert_process_exception, assert_response_success, client_for
 
 from rook.processes.wps_subset import Subset
+from rook.utils.metalink_utils import parse_metalink
 
 TESTS_HOME = Path(__file__).parent.absolute()
 PYWPS_CFG = TESTS_HOME.joinpath("pywps.cfg")
@@ -78,7 +79,7 @@ def test_wps_subset_c3s_cmip6_time_components(get_output):
 
 
 @pytest.mark.xfail(reason="no cmip6 data in /pool/data")
-def test_wps_subset_c3s_cmip6_metadata(get_output, parse_metalink):
+def test_wps_subset_c3s_cmip6_metadata(get_output):
     client = client_for(Service(processes=[Subset()], cfgfiles=[PYWPS_CFG]))
     datainputs = f"collection={C3S_CMIP6_MON_TASMIN_COLLECTION}"
     datainputs += ";time=2010/2010"


### PR DESCRIPTION
## Overview

This PR fixes the smoke tests.

Changes:

* use posix path for pywps config
* using parse_metalink and extract_paths_from_metalink from metalink_utils in tests
* added open_dataset fixture
* using pywps_cfg fixture
* beautifulsoup4 is now a required dependency

## Related Issue / Discussion

## Additional Information


