### PR TITLE
Update smoke tests

### DIFF
--- a/src/rook/utils/concat_utils.py
+++ b/src/rook/utils/concat_utils.py
@@ -118,10 +118,11 @@ class Concat(Operation):
             {dim: (dim, np.array(processed_ds[dim].values, dtype="int32"))}
         )
         processed_ds.coords[dim].attrs = {"standard_name": standard_name}
+        # fix time_bnds issue
+        processed_ds = drop_time_bnds(processed_ds)
         # optional: average
         if self.params.get("apply_average", False):
             processed_ds = average(processed_ds, dims=[dim])
-            processed_ds = drop_time_bnds(processed_ds)
         # subset
         outputs = subset(
             processed_ds,

--- a/src/rook/utils/concat_utils.py
+++ b/src/rook/utils/concat_utils.py
@@ -27,6 +27,8 @@ coord_by_standard_name = {
 
 def drop_time_bnds(ds: xr.Dataset) -> xr.Dataset:
     """
+    Drop time_bnds variable.
+
     Drop time_bnds to avoid xarray CF encoding failures
     with dask + datetime objects.
     """

--- a/src/rook/utils/concat_utils.py
+++ b/src/rook/utils/concat_utils.py
@@ -25,6 +25,16 @@ coord_by_standard_name = {
 }
 
 
+def drop_time_bnds(ds: xr.Dataset) -> xr.Dataset:
+    """
+    Drop time_bnds to avoid xarray CF encoding failures
+    with dask + datetime objects.
+    """
+    if "time_bnds" in ds.variables:
+        ds = ds.drop_vars("time_bnds")
+    return ds
+
+
 def patched_normalise(collection):
     # TODO: this is a patched function of daops to fix the gregorian calendar issue
     norm_collection = collections.OrderedDict()
@@ -111,6 +121,7 @@ class Concat(Operation):
         # optional: average
         if self.params.get("apply_average", False):
             processed_ds = average(processed_ds, dims=[dim])
+            processed_ds = drop_time_bnds(processed_ds)
         # subset
         outputs = subset(
             processed_ds,

--- a/src/rook/utils/regrid_utils.py
+++ b/src/rook/utils/regrid_utils.py
@@ -1,7 +1,15 @@
+from rook.utils.input_utils import parse_custom_grid
+
+
 def run_regrid(args):
     from daops.ops.regrid import regrid
 
     args["apply_fixes"] = False
+
+    # Handle custom grid parsing
+    if args.get("grid") == "custom" and "custom_grid" in args:
+        # parse the string into a tuple/list
+        args["grid"] = parse_custom_grid(args.pop("custom_grid"))
 
     result = regrid(**args)
 

--- a/tests/smoke/test_smoke_checks.py
+++ b/tests/smoke/test_smoke_checks.py
@@ -664,7 +664,6 @@ def test_smoke_execute_c3s_cordex_orchestrate(wps):
     )
 
 
-@pytest.mark.xfail(reason="issue with datatime and xarray+dask")
 def test_smoke_execute_c3s_cmip6_decadal_orchestrate(wps):
     inputs = [
         ("workflow", ComplexDataInput(WF_C3S_CMIP6_DECADAL)),

--- a/tests/smoke/test_smoke_checks.py
+++ b/tests/smoke/test_smoke_checks.py
@@ -675,7 +675,6 @@ def test_smoke_execute_c3s_cmip6_decadal_orchestrate(wps):
     assert "19951116-19951216.nc" in urls[0]
 
 
-@pytest.mark.xfail(reason="calendar fix does not work with latest xarray")
 def test_smoke_execute_c3s_cmip6_decadal_fix_calendar_orchestrate(wps):
     inputs = [
         ("workflow", ComplexDataInput(WF_C3S_CMIP6_DECADAL_2)),

--- a/tests/smoke/test_smoke_checks.py
+++ b/tests/smoke/test_smoke_checks.py
@@ -587,7 +587,7 @@ def test_smoke_execute_c3s_cmip6_regrid_custom(wps):
     urls = wps.execute("regrid", inputs)
     assert len(urls) == 1
     assert (
-        "rlds_Amon_INM-CM5-0_ssp245_r1i1p1f1_gr_20150116-21001216_regrid-nearest_s2d-120x180_cells_grid.nc"
+        "rlds_Amon_INM-CM5-0_ssp245_r1i1p1f1_gr_20150116-21001216_regrid-nearest_s2d-360x720_cells_grid.nc"
         in urls[0]
     )
 

--- a/tests/smoke/test_smoke_checks.py
+++ b/tests/smoke/test_smoke_checks.py
@@ -577,6 +577,20 @@ def test_smoke_execute_c3s_cmip6_regrid(wps):
         in urls[0]
     )
 
+def test_smoke_execute_c3s_cmip6_regrid_custom(wps):
+    inputs = [
+        ("collection", C3S_CMIP6_MON_COLLECTION),
+        ("grid", "custom"),
+        ("custom_grid", "0.5"),
+        ("method", "nearest_s2d"),
+    ]
+    urls = wps.execute("regrid", inputs)
+    assert len(urls) == 1
+    assert (
+        "rlds_Amon_INM-CM5-0_ssp245_r1i1p1f1_gr_20150116-21001216_regrid-nearest_s2d-120x180_cells_grid.nc"
+        in urls[0]
+    )
+
 
 def test_smoke_execute_c3s_cmip5_orchestrate(wps):
     inputs = [

--- a/tests/smoke/test_smoke_checks.py
+++ b/tests/smoke/test_smoke_checks.py
@@ -126,6 +126,29 @@ WF_C3S_CMIP6_REGRID = json.dumps(
     }
 )
 
+WF_C3S_CMIP6_REGRID_CUSTOM= json.dumps(
+    {
+        "doc": "subset+regrid on cmip6 with custom grid",
+        "inputs": {"ds": [C3S_CMIP6_MON_COLLECTION]},
+        "outputs": {"output": "regrid/output"},
+        "steps": {
+            "subset": {
+                "run": "subset",
+                "in": {"collection": "inputs/ds", "time": "2016/2016"},
+            },
+            "regrid": {
+                "run": "regrid",
+                "in": {
+                    "collection": "subset/output",
+                    "method": "nearest_s2d",
+                    "grid": "custom",
+                    "custom_grid": "0.5",
+                },
+            },
+        },
+    }
+)
+
 TC_ALL_DAYS = "day:01,02,03,04,05,06,07,08,09,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"
 
 WF_C3S_CMIP6_360DAY_CALENDAR = json.dumps(
@@ -629,6 +652,17 @@ def test_smoke_execute_c3s_cmip6_regrid_orchestrate(wps):
     assert len(urls) == 1
     assert (
         "rlds_Amon_INM-CM5-0_ssp245_r1i1p1f1_gr_20160116-20161216_regrid-nearest_s2d-180x360_cells_grid.nc"
+        in urls[0]
+    )
+
+def test_smoke_execute_c3s_cmip6_regrid_custom_orchestrate(wps):
+    inputs = [
+        ("workflow", ComplexDataInput(WF_C3S_CMIP6_REGRID_CUSTOM)),
+    ]
+    urls = wps.execute("orchestrate", inputs)
+    assert len(urls) == 1
+    assert (
+        "rlds_Amon_INM-CM5-0_ssp245_r1i1p1f1_gr_20160116-20161216_regrid-nearest_s2d-360x720_cells_grid.nc"
         in urls[0]
     )
 

--- a/tests/smoke/test_smoke_checks.py
+++ b/tests/smoke/test_smoke_checks.py
@@ -126,7 +126,7 @@ WF_C3S_CMIP6_REGRID = json.dumps(
     }
 )
 
-WF_C3S_CMIP6_REGRID_CUSTOM= json.dumps(
+WF_C3S_CMIP6_REGRID_CUSTOM = json.dumps(
     {
         "doc": "subset+regrid on cmip6 with custom grid",
         "inputs": {"ds": [C3S_CMIP6_MON_COLLECTION]},
@@ -600,6 +600,7 @@ def test_smoke_execute_c3s_cmip6_regrid(wps):
         in urls[0]
     )
 
+
 def test_smoke_execute_c3s_cmip6_regrid_custom(wps):
     inputs = [
         ("collection", C3S_CMIP6_MON_COLLECTION),
@@ -654,6 +655,7 @@ def test_smoke_execute_c3s_cmip6_regrid_orchestrate(wps):
         "rlds_Amon_INM-CM5-0_ssp245_r1i1p1f1_gr_20160116-20161216_regrid-nearest_s2d-180x360_cells_grid.nc"
         in urls[0]
     )
+
 
 def test_smoke_execute_c3s_cmip6_regrid_custom_orchestrate(wps):
     inputs = [


### PR DESCRIPTION
## Overview

This PR updates the smoke tests.

Changes:

* Added test for the `regrid` operator with `custom_grid` parameter.
* Fixed `time_bnds` in the `concat` operator.
* Removed `xfail` marker from smoke tests.

## Related Issue / Discussion

## Additional Information


