### PR TITLE
Update atlas v25

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -20,6 +20,7 @@ dependencies:
   - daops >=0.16.0
   - clisops >=0.17.0
   - h5netcdf
+  - h5py
   - roocs-grids >=0.1.2
   - beautifulsoup4 >4.12.3
   # workflow

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,6 +222,7 @@ ignore = [
   "S112", # `try`-`except`-`continue` detected, consider logging the exception
   "C408", # Unnecessary `dict()` call (rewrite as a literal)
   "C419", # Unnecessary list comprehension
+  "RUF067", # `__init__` module should only contain docstrings and re-exports
 ]
 select = [
   "BLE", # blind-except

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
   "daops >=0.16.0",
   "clisops >=0.17.0",
   "h5netcdf >=1.5.0",
+  "h5py",
   "xesmf >=0.9.2",
   "xarray >=2025.6.0",
   "roocs_grids >=0.1.2",

--- a/tests/smoke/test_smoke_checks.py
+++ b/tests/smoke/test_smoke_checks.py
@@ -44,11 +44,11 @@ C3S_IPCC_ATLAS_CMIP6_COLLECTION = "c3s-ipcc-atlas.tnn.CMIP6.historical.mon"
 
 C3S_IPCC_ATLAS_CORDEX_COLLECTION = "c3s-ipcc-atlas.tnn.CORDEX-AFR.historical.mon"
 
-C3S_CICA_ATLAS_ERA5_COLLECTION = "c3s-cica-atlas.cd.ERA5-Land.yr.v2"
+C3S_CICA_ATLAS_ERA5_COLLECTION = "c3s-cica-atlas.cd.ERA5-Land.yr.v25"
 
-C3S_CICA_ATLAS_CORDEX_COLLECTION = "c3s-cica-atlas.cdd.CORDEX-CORE.historical.yr.v2"
+C3S_CICA_ATLAS_CORDEX_COLLECTION = "c3s-cica-atlas.cdd.CORDEX-CORE.historical.yr.v25"
 
-C3S_CICA_ATLAS_CMIP6_COLLECTION = "c3s-cica-atlas.cd.CMIP6.historical.yr.v2"
+C3S_CICA_ATLAS_CMIP6_COLLECTION = "c3s-cica-atlas.cd.CMIP6.historical.yr.v25"
 
 WF_C3S_CMIP5 = json.dumps(
     {
@@ -791,6 +791,7 @@ def test_smoke_execute_c3s_cica_atlas_cmip6_subset(wps):
     urls = wps.execute("subset", inputs)
     assert len(urls) == 1
     assert "data.mips.climate.copernicus.eu" not in urls[0]
+    assert "esg_c3s-cica-atlas" in urls[0]
     assert "cd_CMIP6_historical_yr_20000101-20000101.nc" in urls[0]
 
 
@@ -802,6 +803,7 @@ def test_smoke_execute_c3s_cica_atlas_cordex_subset(wps):
     urls = wps.execute("subset", inputs)
     assert len(urls) == 1
     assert "data.mips.climate.copernicus.eu" not in urls[0]
+    assert "esg_c3s-cica-atlas" in urls[0]
     assert "cdd_CORDEX-CORE_historical_yr_20000101-20000101.nc" in urls[0]
 
 
@@ -813,4 +815,4 @@ def test_smoke_execute_c3s_cica_atlas_era5_subset_no_time_param(wps):
     assert len(urls) == 1
     assert "data.mips.climate.copernicus.eu" in urls[0]
     assert "esg_c3s-cica-atlas" in urls[0]
-    assert "cd_ERA5-Land_yr_1950-2024_v02.nc" in urls[0]
+    assert "cd_ERA5-Land_yr_1950-2024_v025.nc" in urls[0]

--- a/tests/smoke/test_smoke_checks.py
+++ b/tests/smoke/test_smoke_checks.py
@@ -791,7 +791,7 @@ def test_smoke_execute_c3s_cica_atlas_cmip6_subset(wps):
     urls = wps.execute("subset", inputs)
     assert len(urls) == 1
     assert "data.mips.climate.copernicus.eu" not in urls[0]
-    assert "esg_c3s-cica-atlas" in urls[0]
+    # assert "esg_c3s-cica-atlas" in urls[0]
     assert "cd_CMIP6_historical_yr_20000101-20000101.nc" in urls[0]
 
 
@@ -803,7 +803,7 @@ def test_smoke_execute_c3s_cica_atlas_cordex_subset(wps):
     urls = wps.execute("subset", inputs)
     assert len(urls) == 1
     assert "data.mips.climate.copernicus.eu" not in urls[0]
-    assert "esg_c3s-cica-atlas" in urls[0]
+    # assert "esg_c3s-cica-atlas" in urls[0]
     assert "cdd_CORDEX-CORE_historical_yr_20000101-20000101.nc" in urls[0]
 
 
@@ -815,4 +815,4 @@ def test_smoke_execute_c3s_cica_atlas_era5_subset_no_time_param(wps):
     assert len(urls) == 1
     assert "data.mips.climate.copernicus.eu" in urls[0]
     assert "esg_c3s-cica-atlas" in urls[0]
-    assert "cd_ERA5-Land_yr_1950-2024_v025.nc" in urls[0]
+    assert "cd_ERA5-Land_yr_1950-2025_v025.nc" in urls[0]

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -10,7 +10,7 @@ C3S_CMIP6_FX_COLLECTION = (
     "c3s-cmip6.ScenarioMIP.MRI.MRI-ESM2-0.ssp370.r1i1p1f1.fx.orog.gn.v20190603"
 )
 
-C3S_ATLAS_V2_CMIP6_COLLECTION = "c3s-cica-atlas.sst.CMIP6.ssp245.mon.v2"
+C3S_ATLAS_V25_CMIP6_COLLECTION = "c3s-cica-atlas.sst.CMIP6.ssp245.mon.v25"
 
 
 def test_db_catalog_c3s_cmip6_mon(stratus):
@@ -81,9 +81,9 @@ def test_db_catalog_c3s_cmip6_multiple():
 def test_db_catalog_c3s_cica_atlas():
     cat = DBCatalog(project="c3s-cica-atlas")
     # all files
-    result = cat.search(collection=C3S_ATLAS_V2_CMIP6_COLLECTION)
+    result = cat.search(collection=C3S_ATLAS_V25_CMIP6_COLLECTION)
     assert result.matches == 1
-    files = result.files()[C3S_ATLAS_V2_CMIP6_COLLECTION]
+    files = result.files()[C3S_ATLAS_V25_CMIP6_COLLECTION]
     # print(files)
     assert len(files) == 1
-    assert "CMIP6/ssp245/sst_CMIP6_ssp245_mon_201501-210012_v02.nc" in files[0]
+    assert "CMIP6/ssp245/sst_CMIP6_ssp245_mon_201501-210012_v25.nc" in files[0]

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -86,4 +86,4 @@ def test_db_catalog_c3s_cica_atlas():
     files = result.files()[C3S_ATLAS_V25_CMIP6_COLLECTION]
     # print(files)
     assert len(files) == 1
-    assert "CMIP6/ssp245/sst_CMIP6_ssp245_mon_201501-210012_v25.nc" in files[0]
+    assert "CMIP6/ssp245/sst_CMIP6_ssp245_mon_201501-210012_v025.nc" in files[0]

--- a/tests/test_wps_subset.py
+++ b/tests/test_wps_subset.py
@@ -18,11 +18,11 @@ C3S_CMIP6_MON_TASMIN_COLLECTION = (
     "c3s-cmip6.CMIP.MPI-M.MPI-ESM1-2-HR.historical.r1i1p1f1.Amon.tasmin.gn.v20190710"
 )
 
-C3S_ATLAS_V2_CMIP5_COLLECTION = "c3s-cica-atlas.pr.CMIP5.rcp26.mon.v2"
+C3S_ATLAS_V25_CMIP5_COLLECTION = "c3s-cica-atlas.pr.CMIP5.rcp26.mon.v25"
 
-C3S_ATLAS_V2_ERA5_COLLECTION = "c3s-cica-atlas.psl.ERA5.mon.v2"
+C3S_ATLAS_V25_ERA5_COLLECTION = "c3s-cica-atlas.psl.ERA5.mon.v25"
 
-C3S_ATLAS_V2_CORDEX_COLLECTION = "c3s-cica-atlas.huss.CORDEX-CORE.historical.mon.v2"
+C3S_ATLAS_V25_CORDEX_COLLECTION = "c3s-cica-atlas.huss.CORDEX-CORE.historical.mon.v25"
 
 
 def test_wps_subset_cmip6_no_inv(pywps_cfg):
@@ -184,10 +184,10 @@ def test_wps_subset_time_invariant_dataset(get_output, pywps_cfg):
     assert "meta4" in get_output(resp.xml)["output"]
 
 
-@pytest.mark.xfail(reason="no atlas v2 data in /pool/data")
-def test_wps_subset_c3s_atlas_v2_cmip5(get_output, pywps_cfg):
+@pytest.mark.xfail(reason="no atlas v2.5 data in /pool/data")
+def test_wps_subset_c3s_atlas_v25_cmip5(get_output, pywps_cfg):
     client = client_for(Service(processes=[Subset()], cfgfiles=[pywps_cfg]))
-    datainputs = f"collection={C3S_ATLAS_V2_CMIP5_COLLECTION}"
+    datainputs = f"collection={C3S_ATLAS_V25_CMIP5_COLLECTION}"
     datainputs += ";time=2020/2020"
     datainputs += ";time_components=month:jan,feb,mar"
     resp = client.get(
@@ -201,10 +201,10 @@ def test_wps_subset_c3s_atlas_v2_cmip5(get_output, pywps_cfg):
     assert "roocs:pr_CMIP5_rcp26_mon_20200101-20200301.nc" in doc.get_provn()
 
 
-@pytest.mark.xfail(reason="no atlas v2 data in /pool/data")
-def test_wps_subset_c3s_atlas_v2_era5(get_output, pywps_cfg):
+@pytest.mark.xfail(reason="no atlas v2.5 data in /pool/data")
+def test_wps_subset_c3s_atlas_v25_era5(get_output, pywps_cfg):
     client = client_for(Service(processes=[Subset()], cfgfiles=[pywps_cfg]))
-    datainputs = f"collection={C3S_ATLAS_V2_ERA5_COLLECTION}"
+    datainputs = f"collection={C3S_ATLAS_V25_ERA5_COLLECTION}"
     datainputs += ";time=2020/2020"
     datainputs += ";time_components=month:jan,feb,mar"
     resp = client.get(


### PR DESCRIPTION
## Overview

This PR updates the tests for atlas v2.5 data.

Changes:

* Updated smoke tests.
* Updated unit tests.

## Related Issue / Discussion

## Additional Information


