### PR TITLE
Test cleanup: exclude smoke locally and reduce warning noise

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,8 +125,8 @@ lint: ## check style
 ## Testing targets:
 
 test: ## run tests quickly with the default Python
-	@echo "Running all tests (including slow and online tests) ..."
-	@bash -c 'pytest -v'
+	@echo "Running tests excluding smoke (production service checks) ..."
+	@bash -c 'pytest -v -m "not smoke"'
 
 test-tox: ## run tests on every available Python version with tox
 	@bash -c 'tox'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -242,6 +242,17 @@ markers = [
   "online: mark test to need internet connection",
   "smoke: mark test as a smoke/sanity test"
 ]
+filterwarnings = [
+  "ignore:numpy.ndarray size changed, may indicate binary incompatibility.*:RuntimeWarning",
+  "ignore:More than one coordinate variable found for type 'time'. Selecting the best fit.*:UserWarning",
+  "ignore:Variable time has datetime type and a bounds variable but time.encoding does not have units specified.*:UserWarning",
+  "ignore:In a future version of xarray the default value for data_vars will change.*:FutureWarning",
+  "ignore:'crs' was not provided.*:UserWarning",
+  "ignore:.*polys.*large.*segments.*:UserWarning",
+  "ignore:For coordinate variable 'lat' no bounds can be identified.*:UserWarning",
+  "ignore:For coordinate variable 'lon' no bounds can be identified.*:UserWarning",
+  "ignore:The file '.*/grid_weights/.*' already exists.*:UserWarning"
+]
 
 [tool.ruff]
 src = ["rook"]

--- a/src/rook/director/alignment.py
+++ b/src/rook/director/alignment.py
@@ -45,7 +45,11 @@ class SubsetAlignmentChecker:
         if Path(fpath).as_posix().startswith("http"):
             fpath = url_to_file_path(fpath)
 
-        ds = xr.open_dataset(fpath, use_cftime=True)
+        try:
+            time_coder = xr.coders.CFDatetimeCoder(use_cftime=True)
+            ds = xr.open_dataset(fpath, decode_times=time_coder)
+        except (AttributeError, TypeError):
+            ds = xr.open_dataset(fpath, use_cftime=True)
         start = to_isoformat(ds.time.values[0])
         end = to_isoformat(ds.time.values[-1])
         ds.close()

--- a/src/rook/utils/metalink_utils.py
+++ b/src/rook/utils/metalink_utils.py
@@ -31,7 +31,8 @@ def build_metalink(identity, description, workdir, file_uris, file_type="NetCDF"
 
 def extract_paths_from_metalink(path):
     path = path.replace("file://", "")
-    xml = Path(path).open().read()
+    with Path(path).open() as fp:
+        xml = fp.read()
     return parse_metalink(xml)
 
 

--- a/src/rook/workflow.py
+++ b/src/rook/workflow.py
@@ -30,7 +30,8 @@ def is_file(data):
 
 def load_wfdoc(data):
     if is_file(data):
-        wfdoc = yaml.load(Path(data).open("rb"), Loader=yaml.SafeLoader)
+        with Path(data).open("rb") as fp:
+            wfdoc = yaml.load(fp, Loader=yaml.SafeLoader)
     else:
         wfdoc = yaml.load(data, Loader=yaml.SafeLoader)
     return wfdoc

--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import pytest
 import requests
 from owslib.wps import WebProcessingService, monitorExecution
+from owslib.util import ServiceException
 from pywps import configuration as config
 
 from rook.utils.metalink_utils import parse_metalink
@@ -45,5 +46,10 @@ class RookWPS:
 
 @pytest.fixture
 def wps():
-    wps_ = RookWPS(server_url())
+    url = server_url()
+    wps_ = RookWPS(url)
+    try:
+        wps_.getcapabilities()
+    except (requests.RequestException, ServiceException) as exc:
+        pytest.skip(f"WPS endpoint unavailable for smoke tests at {url}: {exc}")
     return wps_


### PR DESCRIPTION

## Overview

This PR cleans up the tests and reduces the warnings.

Changes:

- run default make test with non-smoke marker for local/dev runs

- skip smoke fixture when WPS endpoint is unavailable

- fix ResourceWarning sources by closing workflow/metalink file handles

- update xarray cftime decoding usage with compatibility fallback

- add targeted pytest warning filters for third-party noise


## Related Issue / Discussion

## Additional Information


