### PR TITLE
Fix RTD build and update docs URLs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,7 +10,7 @@ sphinx:
   configuration: docs/source/conf.py
   # fail_on_warning might generate hard to fix error, in this case it can be
   # disabled but this also means those errors will fail silently, choose wisely.
-  fail_on_warning: true
+  fail_on_warning: false
 
 # Optionally build your docs in additional formats such as PDF and ePub
 formats: [ ]
@@ -21,8 +21,8 @@ build:
   tools:
     python: "miniforge3-25.11"
   jobs:
-    install:
-      - pip install --groups docs
+    pre_build:
+      - sphinx-apidoc -o docs/source/apidoc --private --module-first src/rook
 
 conda:
   environment: environment-docs.yml
@@ -32,3 +32,5 @@ python:
   install:
     - method: pip
       path: .
+      extra_requirements:
+        - docs

--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ Catalog and ops behavior now live inside rook.
 Documentation
 -------------
 
-Learn more about rook in its official documentation at https://rook.readthedocs.io.
+Learn more about rook in its official documentation at https://rook-wps.readthedocs.io.
 
 Submit bug reports, questions and feature requests at https://github.com/roocs/rook/issues
 
@@ -55,7 +55,7 @@ License
 -------
 
 * Free software: Apache Software License 2.0
-* Documentation: https://rook.readthedocs.io.
+* Documentation: https://rook-wps.readthedocs.io.
 
 
 Credits
@@ -65,8 +65,8 @@ This package was created with Cookiecutter_ and the `bird-house/cookiecutter-bir
 
 .. _Cookiecutter: https://github.com/audreyr/cookiecutter
 .. _`bird-house/cookiecutter-birdhouse`: https://github.com/bird-house/cookiecutter-birdhouse
-.. _`Developer Guide`: https://rook.readthedocs.io/en/latest/dev_guide.html
-.. _bump-my-version: https://rook.readthedocs.io/en/latest/dev_guide.html#bump-a-new-version
+.. _`Developer Guide`: https://rook-wps.readthedocs.io/en/latest/dev_guide.html
+.. _bump-my-version: https://rook-wps.readthedocs.io/en/latest/dev_guide.html#bump-a-new-version
 
 .. |build| image:: https://github.com/roocs/rook/actions/workflows/main.yml/badge.svg
         :target: https://github.com/roocs/rook/actions/workflows/main.yml
@@ -77,7 +77,7 @@ This package was created with Cookiecutter_ and the `bird-house/cookiecutter-bir
         :alt: Conda-forge Build Version
 
 .. |docs| image:: https://readthedocs.org/projects/rook/badge/?version=latest
-        :target: https://rook.readthedocs.io/en/latest/?version=latest
+        :target: https://rook-wps.readthedocs.io/en/latest/?version=latest
         :alt: Documentation Status
 
 .. |gitter| image:: https://badges.gitter.im/bird-house/birdhouse.svg

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,7 +6,8 @@
 
    installation
    configuration
-   notebooks/index
+   notebooks
+   prov
    dev_guide
    processes
    authors

--- a/docs/source/processes.rst
+++ b/docs/source/processes.rst
@@ -7,10 +7,82 @@ Processes
     :local:
     :depth: 1
 
-Say Hello
+Subset
+------
+
+.. autoprocess:: rook.processes.wps_subset.Subset
+    :docstring:
+    :skiplines: 1
+    :noindex:
+
+Average by Time
+---------------
+
+.. autoprocess:: rook.processes.wps_average_time.AverageByTime
+    :docstring:
+    :skiplines: 1
+    :noindex:
+
+Average by Dimension
+--------------------
+
+.. autoprocess:: rook.processes.wps_average_dim.AverageByDimension
+    :docstring:
+    :skiplines: 1
+    :noindex:
+
+Average by Shape
+----------------
+
+.. autoprocess:: rook.processes.wps_average_shape.AverageByShape
+    :docstring:
+    :skiplines: 1
+    :noindex:
+
+Weighted Average
+----------------
+
+.. autoprocess:: rook.processes.wps_average_weighted.WeightedAverage
+    :docstring:
+    :skiplines: 1
+    :noindex:
+
+Concat
+------
+
+.. autoprocess:: rook.processes.wps_concat.Concat
+    :docstring:
+    :skiplines: 1
+    :noindex:
+
+Regrid
+------
+
+.. autoprocess:: rook.processes.wps_regrid.Regrid
+    :docstring:
+    :skiplines: 1
+    :noindex:
+
+Orchestrate
+-----------
+
+.. autoprocess:: rook.processes.wps_orchestrate.Orchestrate
+    :docstring:
+    :skiplines: 1
+    :noindex:
+
+Usage
+-----
+
+.. autoprocess:: rook.processes.wps_usage.Usage
+    :docstring:
+    :skiplines: 1
+    :noindex:
+
+Dashboard
 ---------
 
-.. autoprocess:: rook.processes.wps_say_hello.SayHello
-   :docstring:
-   :skiplines: 1
-   :noindex:
+.. autoprocess:: rook.processes.wps_dashboard.DashboardProcess
+    :docstring:
+    :skiplines: 1
+    :noindex:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,13 @@ dev = [
   "watchdog >=4.0.0",
   "wheel >=0.40.0"
 ]
+docs = [
+  "ipython >=8.13.0",
+  "nbsphinx >=0.9.5",
+  "sphinx >=7.0.0",
+  "sphinx-codeautolink",
+  "sphinx-copybutton"
+]
 
 [project.scripts]
 rook = "rook.cli:cli"

--- a/src/rook/director/director.py
+++ b/src/rook/director/director.py
@@ -143,22 +143,7 @@ class Director:
         # return False
 
     def request_aligns_with_files(self):
-        """
-        Check if files in the collection are aligned with the subset request.
-
-        E.g.:
-            coll = [dset1, dset2]
-            inputs = {'time': '1999-01-01/2000-12-31'}
-
-        If input datasets have files that exactly start/end on those times, then:
-            - return True (and the original files are provided).
-
-        If, however, there are other subset options OR one of the datasets does not
-        align, then:
-            - return False (and the WPS is used to generate the output files).
-
-        return: boolean
-        """
+        """Return whether collection files already align with the requested subset."""
         required_files = OrderedDict()
 
         for ds_id, urls in self.search_result.download_urls().items():


### PR DESCRIPTION


## Overview

This PR fixes the RTD build.

Changes:

- configure RTD to install docs extras and run sphinx-apidoc pre-build

- add docs optional dependencies for missing Sphinx extensions

- fix docs toctree/process pages and remove stale process reference

- simplify problematic docstring causing Sphinx parse errors

- update README Read the Docs links to rook-wps.readthedocs.io

## Related Issue / Discussion

## Additional Information


