### PR TITLE
skip unused apply_fixes parameter

### DIFF
--- a/docs/source/prov-example.json
+++ b/docs/source/prov-example.json
@@ -45,12 +45,10 @@
       }
     ],
     "subset_tas_1": {
-      "time": "2016-01-01/2020-12-30",
-      "apply_fixes": false
+      "time": "2016-01-01/2020-12-30"
     },
     "subset_tas_2": {
-      "time": "2017-01-01/2017-12-30",
-      "apply_fixes": false
+      "time": "2017-01-01/2017-12-30"
     }
   },
   "wasAssociatedWith": {

--- a/src/rook/director/director.py
+++ b/src/rook/director/director.py
@@ -42,24 +42,6 @@ class Director:
                 raise InvalidCollection()
 
             self._resolve()
-        # if enabled for the project then check if a fix will be applied
-        self._check_apply_fixes()
-
-    def use_fixes(self):
-        # TODO: don't use fixes
-        return False
-        # return config.get_project_config(self.project).get("use_fixes", False)
-
-    def _check_apply_fixes(self):
-        if (
-            self.use_fixes()
-            and self.inputs.get("apply_fixes")
-            and not self.use_original_files
-            and self.requires_fixes()
-        ):
-            self.inputs["apply_fixes"] = True
-        else:
-            self.inputs["apply_fixes"] = False
 
     def _resolve(self):
         """
@@ -72,8 +54,6 @@ class Director:
             If YES: return (and use original files)
         - Does the user require data to be pre-checked AND has the collection been pre-checked?
             If NO: raise Exception
-        - Does the user want to apply fixes AND fixes are required for this collection?
-            If YES: return (and use WPS)
         - Does the requested temporal subset align with files in all datasets in this collection?
             If YES: return (and use original files)
             If NO: return (and use WPS)
@@ -109,10 +89,6 @@ class Director:
         ):
             raise ProcessError("Data has not been pre-checked")
 
-        # Check if fixes are required. If so, then return (and subset will be generated).
-        if self.inputs.get("apply_fixes") and self.requires_fixes():
-            return
-
         # TODO: quick fix for average, regrid and concat. Don't use original files for these operators.
         if "dims" in self.inputs or "freq" in self.inputs or "grid" in self.inputs:
             return
@@ -123,24 +99,6 @@ class Director:
             pass
 
         # If we got here: then WPS will be used, because `self.use_original_files == False`
-
-    def requires_fixes(self):
-        # TODO: don't use fixes
-        return False
-        # if not self.use_fixes():
-        #     return False
-
-        # if self.search_result:
-        #     ds_ids = self.search_result.files()
-        # else:
-        #     ds_ids = self.coll
-        # for ds_id in ds_ids:
-        #     fix = fixer.Fixer(ds_id)
-
-        #     if fix.pre_processor or fix.post_processors:
-        #         return True
-
-        # return False
 
     def request_aligns_with_files(self):
         """Return whether collection files already align with the requested subset."""

--- a/src/rook/io/datasets.py
+++ b/src/rook/io/datasets.py
@@ -123,12 +123,12 @@ _OPENERS = {
 }
 
 
-def open_dataset(source: DatasetSource, *, apply_fixes=True):
-    """Open an xarray Dataset and optionally apply rook-native fixes."""
+def open_dataset(source: DatasetSource):
+    """Open an xarray Dataset and apply catalog-specific fixes when available."""
     opener = _OPENERS[detect_format(source)]
     ds = opener(source, get_storage_options(source))
 
-    if apply_fixes and source.dataset_id:
+    if source.dataset_id:
         ds = apply_dataset_fixes(source.dataset_id, ds)
 
     return ds

--- a/src/rook/operator.py
+++ b/src/rook/operator.py
@@ -9,7 +9,7 @@ from rook.utils.average_utils import (
     run_average_by_time,
 )
 from rook.utils.concat_utils import run_concat
-from rook.utils.input_utils import resolve_to_file_paths
+from rook.utils.input_utils import clean_inputs, resolve_to_file_paths
 from rook.utils.regrid_utils import run_regrid
 from rook.utils.subset_utils import run_subset
 from rook.utils.weighted_average_utils import run_weighted_average
@@ -27,7 +27,6 @@ class Operator:
             output_dir_ = output_dir
         self.config = {
             "output_dir": output_dir_,
-            # "apply_fixes": apply_fixes,
             # 'original_files': original_files
             # 'chunk_rules': dconfig.chunk_rules,
             # 'filenamer': dconfig.filenamer,
@@ -43,8 +42,8 @@ class Operator:
         if is_file_list(collection):
             # This block is called if this is NOT the first stage of a workflow, and
             # the collection will be a file list (one or more files)
-            args["apply_fixes"] = False
             kwargs = deepcopy(args)
+            clean_inputs(kwargs)
             file_paths = resolve_to_file_paths(args.get("collection"))
             kwargs["collection"] = FileMapper(file_paths)
             output_uris = runner(kwargs)  # this needs to be in a list

--- a/src/rook/processes/wps_average_dim.py
+++ b/src/rook/processes/wps_average_dim.py
@@ -53,7 +53,7 @@ class AverageByDimension(Process):
                 "apply_fixes",
                 "Apply Fixes",
                 data_type="boolean",
-                abstract="Apply fixes to datasets.",
+                abstract="Deprecated compatibility parameter. Rook now applies required dataset fixes automatically.",
                 default="1",
                 min_occurs=1,
                 max_occurs=1,
@@ -112,7 +112,6 @@ class AverageByDimension(Process):
         inputs = {
             "collection": collection,
             "output_dir": self.workdir,
-            "apply_fixes": parse_wps_input(request.inputs, "apply_fixes", default=True),
             "pre_checked": parse_wps_input(
                 request.inputs, "pre_checked", default=False
             ),

--- a/src/rook/processes/wps_average_shape.py
+++ b/src/rook/processes/wps_average_shape.py
@@ -53,7 +53,7 @@ class AverageByShape(Process):
                 "apply_fixes",
                 "Apply Fixes",
                 data_type="boolean",
-                abstract="Apply fixes to datasets.",
+                abstract="Deprecated compatibility parameter. Rook now applies required dataset fixes automatically.",
                 default="1",
                 min_occurs=1,
                 max_occurs=1,
@@ -111,7 +111,6 @@ class AverageByShape(Process):
         inputs = {
             "collection": collection,
             "output_dir": self.workdir,
-            "apply_fixes": parse_wps_input(request.inputs, "apply_fixes", default=True),
             "pre_checked": parse_wps_input(
                 request.inputs, "pre_checked", default=False
             ),

--- a/src/rook/processes/wps_average_time.py
+++ b/src/rook/processes/wps_average_time.py
@@ -47,7 +47,7 @@ class AverageByTime(Process):
                 "apply_fixes",
                 "Apply Fixes",
                 data_type="boolean",
-                abstract="Apply fixes to datasets.",
+                abstract="Deprecated compatibility parameter. Rook now applies required dataset fixes automatically.",
                 default="1",
                 min_occurs=1,
                 max_occurs=1,
@@ -106,7 +106,6 @@ class AverageByTime(Process):
         inputs = {
             "collection": collection,
             "output_dir": self.workdir,
-            "apply_fixes": parse_wps_input(request.inputs, "apply_fixes", default=True),
             "pre_checked": parse_wps_input(
                 request.inputs, "pre_checked", default=False
             ),

--- a/src/rook/processes/wps_average_weighted.py
+++ b/src/rook/processes/wps_average_weighted.py
@@ -76,7 +76,6 @@ class WeightedAverage(Process):
             "collection": collection,
             "output_dir": self.workdir,
             "dims": ["latitude", "longitude"],
-            "apply_fixes": False,
             "pre_checked": False,
         }
 

--- a/src/rook/processes/wps_concat.py
+++ b/src/rook/processes/wps_concat.py
@@ -79,7 +79,7 @@ class Concat(Process):
                 "apply_fixes",
                 "Apply Fixes",
                 data_type="boolean",
-                abstract="Apply fixes to datasets.",
+                abstract="Deprecated compatibility parameter. Rook now applies required dataset fixes automatically.",
                 default="1",
                 min_occurs=1,
                 max_occurs=1,
@@ -137,7 +137,6 @@ class Concat(Process):
         inputs = {
             "collection": collection,
             "output_dir": self.workdir,
-            "apply_fixes": parse_wps_input(request.inputs, "apply_fixes", default=True),
             "pre_checked": parse_wps_input(
                 request.inputs, "pre_checked", default=False
             ),

--- a/src/rook/processes/wps_regrid.py
+++ b/src/rook/processes/wps_regrid.py
@@ -126,7 +126,6 @@ class Regrid(Process):
         inputs = {
             "collection": collection,
             "output_dir": self.workdir,
-            "apply_fixes": False,
             "pre_checked": False,
             "method": parse_wps_input(request.inputs, "method", default="nearest_s2d"),
             "grid": get_grid_param(grid, custom_grid),

--- a/src/rook/processes/wps_subset.py
+++ b/src/rook/processes/wps_subset.py
@@ -80,7 +80,7 @@ class Subset(Process):
                 "apply_fixes",
                 "Apply Fixes",
                 data_type="boolean",
-                abstract="Apply fixes to datasets.",
+                abstract="Deprecated compatibility parameter. Rook now applies required dataset fixes automatically.",
                 default="1",
                 min_occurs=1,
                 max_occurs=1,
@@ -144,7 +144,6 @@ class Subset(Process):
         inputs = {
             "collection": collection,
             "output_dir": self.workdir,
-            "apply_fixes": parse_wps_input(request.inputs, "apply_fixes", default=True),
             "pre_checked": parse_wps_input(
                 request.inputs, "pre_checked", default=False
             ),

--- a/src/rook/provenance.py
+++ b/src/rook/provenance.py
@@ -131,7 +131,6 @@ class Provenance:
             "method",
             "grid",
             "adaptive_masking_threshold",
-            "apply_fixes",
             "apply_average",
         ]:
             if param in parameters:

--- a/src/rook/utils/input_utils.py
+++ b/src/rook/utils/input_utils.py
@@ -78,7 +78,7 @@ def parse_wps_input(inputs, key, as_sequence=False, must_exist=False, default=No
 
 def clean_inputs(inputs):
     """Remove common arguments not required in processing calls."""
-    to_remove = ("pre_checked", "original_files")
+    to_remove = ("pre_checked", "original_files", "apply_fixes")
 
     for key in to_remove:
         if key in inputs:

--- a/src/rook/utils/ops/average.py
+++ b/src/rook/utils/ops/average.py
@@ -33,7 +33,6 @@ def average_over_dims(
     output_type="netcdf",
     split_method="time:auto",
     file_namer="standard",
-    apply_fixes=True,
 ):
     return Average(**locals()).calculate()
 
@@ -61,7 +60,6 @@ def average_shape(
     output_type="netcdf",
     split_method="time:auto",
     file_namer="standard",
-    apply_fixes=True,
 ):
     return AverageShape(**locals()).calculate()
 
@@ -87,6 +85,5 @@ def average_time(
     output_type="netcdf",
     split_method="time:auto",
     file_namer="standard",
-    apply_fixes=True,
 ):
     return AverageTime(**locals()).calculate()

--- a/src/rook/utils/ops/base.py
+++ b/src/rook/utils/ops/base.py
@@ -16,14 +16,12 @@ class Operation:
         split_method="time:auto",
         output_dir=None,
         output_type="netcdf",
-        apply_fixes=True,
         **params,
     ):
         self._file_namer = file_namer
         self._split_method = split_method
         self._output_dir = output_dir
         self._output_type = output_type
-        self._apply_fixes = apply_fixes
         self._resolve_params(collection, **params)
         self._consolidate_collection()
 
@@ -52,7 +50,7 @@ class Operation:
 
         self.params.update(config)
 
-        norm_collection = normalise.normalise(self.collection, self._apply_fixes)
+        norm_collection = normalise.normalise(self.collection)
 
         rs = normalise.ResultSet(vars())
 

--- a/src/rook/utils/ops/concat.py
+++ b/src/rook/utils/ops/concat.py
@@ -125,7 +125,6 @@ def _concat(
     output_type="netcdf",
     split_method="time:auto",
     file_namer="standard",
-    apply_fixes=True,
     apply_average=False,
 ):
     return Concat(**locals())._calculate()
@@ -141,7 +140,6 @@ def concat(
     output_type="netcdf",
     split_method="time:auto",
     file_namer="standard",
-    apply_fixes=True,
     apply_average=False,
 ):
     args = dict(
@@ -154,7 +152,6 @@ def concat(
         output_type=output_type,
         split_method=split_method,
         file_namer=file_namer,
-        apply_fixes=apply_fixes,
         apply_average=apply_average,
     )
     return _concat(**args)

--- a/src/rook/utils/ops/normalise.py
+++ b/src/rook/utils/ops/normalise.py
@@ -9,13 +9,13 @@ from rook.io.datasets import open_dataset
 from .helpers import ordered_dict
 
 
-def normalise(collection, apply_fixes=True):
-    """Open input collections and apply fixes when requested."""
+def normalise(collection):
+    """Open input collections."""
     logger.info(f"Working on datasets: {collection}")
     norm_collection = ordered_dict()
 
     for source in collection:
-        ds = open_dataset(source, apply_fixes=apply_fixes)
+        ds = open_dataset(source)
         norm_collection[source.key] = ds
 
     return norm_collection

--- a/src/rook/utils/ops/regrid.py
+++ b/src/rook/utils/ops/regrid.py
@@ -32,6 +32,5 @@ def regrid(
     output_type="netcdf",
     split_method="time:auto",
     file_namer="standard",
-    apply_fixes=True,
 ):
     return Regrid(**locals()).calculate()

--- a/src/rook/utils/ops/subset.py
+++ b/src/rook/utils/ops/subset.py
@@ -1,9 +1,7 @@
-"""Subset operation with rook-specific fix application."""
+"""Subset operation."""
 
 from clisops.ops.subset import subset as clisops_subset
 from clisops.parameter import parameterise
-
-from rook.utils.apply_fixes import apply_fixes
 
 from .base import Operation
 from . import normalise
@@ -34,12 +32,11 @@ class Subset(Operation):
 
         self.params.update(config)
 
-        norm_collection = normalise.normalise(self.collection, False)
+        norm_collection = normalise.normalise(self.collection)
         rs = normalise.ResultSet(vars())
 
-        for dset, norm_collection_ in norm_collection.items():
-            fixed_collection = apply_fixes(dset, norm_collection_)
-            rs.add(dset, clisops_subset(fixed_collection, **self.params))
+        for dset, dataset in norm_collection.items():
+            rs.add(dset, clisops_subset(dataset, **self.params))
 
         return rs
 
@@ -54,6 +51,5 @@ def subset(
     output_type="netcdf",
     split_method="time:auto",
     file_namer="standard",
-    apply_fixes=False,
 ):
     return Subset(**locals()).calculate()

--- a/src/rook/utils/regrid_utils.py
+++ b/src/rook/utils/regrid_utils.py
@@ -3,8 +3,6 @@ from rook.utils.ops.regrid import regrid as ops_regrid
 
 
 def run_regrid(args):
-    args["apply_fixes"] = False
-
     # Handle custom grid parsing
     if args.get("grid") == "custom" and "custom_grid" in args:
         # parse the string into a tuple/list

--- a/src/rook/workflow.py
+++ b/src/rook/workflow.py
@@ -39,7 +39,6 @@ def load_wfdoc(data):
 
 def replace_inputs(wfdoc):
     steps = {}
-    start_steps = []
     for step_id, step in wfdoc["steps"].items():
         steps[step_id] = deepcopy(step)
         # replace inputs
@@ -47,15 +46,6 @@ def replace_inputs(wfdoc):
             if isinstance(arg, str) and arg.startswith("inputs/"):
                 input_id = arg.split("/")[1]
                 steps[step_id]["in"][arg_id] = wfdoc["inputs"][input_id]
-                start_steps.append(step_id)
-    for step_id in steps.keys():
-        # fixes are only applied to start steps
-        if step_id in start_steps:
-            steps[step_id]["in"]["apply_fixes"] = steps[step_id]["in"].get(
-                "apply_fixes", False
-            )
-        else:
-            steps[step_id]["in"]["apply_fixes"] = False
     LOGGER.debug(f"steps: {steps}")
     return steps
 

--- a/tests/test_director/test_director.py
+++ b/tests/test_director/test_director.py
@@ -87,18 +87,6 @@ class TestDirectorCMIP6:
         with pytest.raises(ProcessError):
             Director(self.collection, inputs)
 
-    def apply_fixes_not_required(self):
-        # no subset so original files
-        inputs = {"apply_fixes": True}
-        d = Director(self.collection, inputs)
-        assert d.use_original_files is True
-        assert list(d.original_file_urls.items())[0][1] == [
-            "https://data.mips.climate.copernicus.eu/thredds/fileServer"
-            "/esg_c3s-cmip6/CMIP/IPSL/IPSL-CM6A-LR/historical"
-            "/r1i1p1f1/Amon/rlds/gr/v20180803/rlds_Amon_"
-            "IPSL-CM6A-LR_historical_r1i1p1f1_gr_185001-201412.nc"
-        ]
-
     def test_area_or_level(self):
         # WPS output
         inputs = {"area": "0.,49.,10.,65"}
@@ -287,20 +275,3 @@ def test_catalog_pre_checked_requires_characterised_data(catalog_director):
 
     with pytest.raises(ProcessError, match="Data has not been pre-checked"):
         Director(collection, {"pre_checked": True})
-
-
-# need to test a  different dataset that has been characterised:
-
-# def test_apply_fixes_required(self):
-#     # wps output - can't test this with this dataset
-#     inputs = {"apply_fixes": True}
-#     pass
-#     d = Director(self.collection, inputs)
-#     assert d.use_original_files is False
-#
-#
-# def test_pre_checked_charactersied(self):
-#     # fine - can't test this with this dataset
-#     inputs = {"pre_checked": True}
-#     pass
-#     d = Director(self.collection, inputs)

--- a/tests/test_io_datasets.py
+++ b/tests/test_io_datasets.py
@@ -52,15 +52,13 @@ def test_open_dataset_applies_fixes(monkeypatch):
     monkeypatch.setattr(helpers, "apply_dataset_fixes", fake_apply)
     monkeypatch.setattr(helpers, "is_kerchunk_file", lambda _: False)
 
-    result = helpers.open_dataset(
-        source("project.dataset", ["a.nc"]), apply_fixes=True
-    )
+    result = helpers.open_dataset(source("project.dataset", ["a.nc"]))
 
     assert result == "FIXED"
     assert calls == {"open": 1, "fix": 1}
 
 
-def test_open_dataset_skips_fixes_when_disabled(monkeypatch):
+def test_open_dataset_applies_catalog_fixes_without_external_switch(monkeypatch):
     calls = {"open": 0, "fix": 0}
 
     def fake_open(file_paths):
@@ -75,12 +73,10 @@ def test_open_dataset_skips_fixes_when_disabled(monkeypatch):
     monkeypatch.setattr(helpers, "apply_dataset_fixes", fake_apply)
     monkeypatch.setattr(helpers, "is_kerchunk_file", lambda _: False)
 
-    result = helpers.open_dataset(
-        source("project.dataset", ["a.nc"]), apply_fixes=False
-    )
+    result = helpers.open_dataset(source("project.dataset", ["a.nc"]))
 
-    assert result == "DATASET"
-    assert calls == {"open": 1, "fix": 0}
+    assert result == "FIXED"
+    assert calls == {"open": 1, "fix": 1}
 
 
 def test_open_dataset_skips_fixes_for_kerchunk(monkeypatch):
@@ -98,9 +94,7 @@ def test_open_dataset_skips_fixes_for_kerchunk(monkeypatch):
     monkeypatch.setattr(helpers, "apply_dataset_fixes", fake_apply)
     monkeypatch.setattr(helpers, "is_kerchunk_file", lambda _: True)
 
-    result = helpers.open_dataset(
-        source(None, ["kerchunk.json"]), apply_fixes=True
-    )
+    result = helpers.open_dataset(source(None, ["kerchunk.json"]))
 
     assert result == "DATASET"
     assert calls == {"open": 1, "fix": 0}
@@ -114,7 +108,7 @@ def test_open_dataset_skips_fixes_without_catalog_dataset_id(monkeypatch):
 
     monkeypatch.setattr(helpers, "apply_dataset_fixes", fail_apply_fixes)
 
-    result = helpers.open_dataset(source(None, "direct.nc"), apply_fixes=True)
+    result = helpers.open_dataset(source(None, "direct.nc"))
 
     assert result == "DATASET"
 
@@ -193,7 +187,7 @@ def test_open_dataset_opens_local_zarr_store(tmp_path):
     expected = xr.Dataset({"tas": ("time", [280.0, 281.0])})
     expected.to_zarr(store, mode="w")
 
-    result = helpers.open_dataset(source(None, str(store)), apply_fixes=False)
+    result = helpers.open_dataset(source(None, str(store)))
 
     xr.testing.assert_equal(result, expected)
     result.close()
@@ -209,9 +203,9 @@ def test_open_dataset_keeps_local_netcdf_path(tmp_path, monkeypatch):
 
     monkeypatch.setattr(helpers.xr, "open_zarr", fail_open_zarr)
 
-    result = helpers.open_dataset(
-        source("project.dataset", [str(path)]), apply_fixes=False
-    )
+    monkeypatch.setattr(helpers, "apply_dataset_fixes", lambda _ds_id, ds: ds)
+
+    result = helpers.open_dataset(source("project.dataset", [str(path)]))
 
     xr.testing.assert_equal(result, expected)
     result.close()
@@ -232,10 +226,7 @@ def test_open_dataset_passes_s3_options_to_zarr(monkeypatch):
         {"s3": {"anon": "true", "endpoint_url": "https://s3.example.org"}},
     )
 
-    result = helpers.open_dataset(
-        source(None, "s3://example-bucket/path/example.zarr"),
-        apply_fixes=False,
-    )
+    result = helpers.open_dataset(source(None, "s3://example-bucket/path/example.zarr"))
 
     assert result == "DATASET"
     assert calls == {
@@ -257,9 +248,7 @@ def test_open_dataset_skips_fixes_for_direct_zarr(monkeypatch):
 
     monkeypatch.setattr(helpers, "apply_dataset_fixes", fail_apply_fixes)
 
-    result = helpers.open_dataset(
-        source(None, "/data/example.zarr"), apply_fixes=True
-    )
+    result = helpers.open_dataset(source(None, "/data/example.zarr"))
 
     assert result == "DATASET"
 
@@ -310,9 +299,7 @@ def test_open_dataset_passes_s3_options_to_kerchunk(monkeypatch):
     monkeypatch.setattr(helpers, "open_xr_dataset", fake_open)
     monkeypatch.setattr(config, "_CONFIG", {"s3": {"anon": "true"}})
 
-    result = helpers.open_dataset(
-        source(None, "s3://bucket/reference.json"), apply_fixes=False
-    )
+    result = helpers.open_dataset(source(None, "s3://bucket/reference.json"))
 
     assert result == "DATASET"
     assert calls == {
@@ -343,10 +330,7 @@ def test_open_dataset_passes_s3_backend_kwargs(monkeypatch):
         {"s3": {"anon": "true", "endpoint_url": "https://s3.example.org"}},
     )
 
-    _ = helpers.open_dataset(
-        source(None, "s3://example-bucket/path/file.nc"),
-        apply_fixes=False,
-    )
+    _ = helpers.open_dataset(source(None, "s3://example-bucket/path/file.nc"))
 
     assert calls["open_kwargs"] == {
         "backend_kwargs": {

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -39,7 +39,9 @@ def test_direct_file_collection_is_processed_without_director(tmp_path, monkeypa
     )
 
     assert output_uris == ["processed.nc"]
-    assert operator.runner_inputs["apply_fixes"] is False
+    assert "apply_fixes" not in operator.runner_inputs
+    assert "original_files" not in operator.runner_inputs
+    assert "pre_checked" not in operator.runner_inputs
     assert isinstance(operator.runner_inputs["collection"], FileMapper)
     assert operator.runner_inputs["output_dir"].startswith(tmp_path.as_posix())
 

--- a/tests/test_ops_zarr.py
+++ b/tests/test_ops_zarr.py
@@ -33,7 +33,6 @@ def test_subset_local_zarr_store(tmp_path):
     result = subset(
         collection=str(store),
         output_dir=output_dir,
-        apply_fixes=False,
     )
 
     assert len(result.file_uris) == 1


### PR DESCRIPTION
## Overview

This PR removes the unused `apply_fixes` parameter. Fix are applied internally. The WPS parameter for `apply_fixes` is kept for backward compatibility but marked as deprecated.

## Related Issue / Discussion

## Additional Information


