### PR TITLE
removed unused pre_checked parameter

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -30,7 +30,7 @@ Cover at least:
 - generating a subset when the request does not align with whole files;
 - operators that must always process data rather than return original files;
 - a later workflow step receiving files produced by an earlier step;
-- errors for unknown collections and unavailable pre-checked data.
+- errors for unknown collections.
 
 Tests should describe observable behavior, not preserve incidental class or
 module structure. They will provide room to simplify the implementation.

--- a/src/rook/director/director.py
+++ b/src/rook/director/director.py
@@ -10,7 +10,7 @@ from rook.catalog import get_catalog
 
 from ..utils.input_utils import clean_inputs
 from .alignment import SubsetAlignmentChecker
-from .compat import ResultSet, is_characterised
+from .compat import ResultSet
 
 
 def wrap_director(collection, inputs, runner):
@@ -52,8 +52,6 @@ class Director:
             If NO: raise Exception
         - Does the user want to access original files only?
             If YES: return (and use original files)
-        - Does the user require data to be pre-checked AND has the collection been pre-checked?
-            If NO: raise Exception
         - Does the requested temporal subset align with files in all datasets in this collection?
             If YES: return (and use original files)
             If NO: return (and use WPS)
@@ -82,12 +80,6 @@ class Director:
             self.original_file_urls = self.search_result.download_urls()
             self.use_original_files = True
             return
-
-        # Raise exception if "pre_checked" selected but data has not been characterised by dachar
-        if self.inputs.get("pre_checked") and not is_characterised(
-            self.coll, require_all=True
-        ):
-            raise ProcessError("Data has not been pre-checked")
 
         # TODO: quick fix for average, regrid and concat. Don't use original files for these operators.
         if "dims" in self.inputs or "freq" in self.inputs or "grid" in self.inputs:

--- a/src/rook/processes/wps_average_dim.py
+++ b/src/rook/processes/wps_average_dim.py
@@ -44,7 +44,7 @@ class AverageByDimension(Process):
                 "pre_checked",
                 "Pre-Checked",
                 data_type="boolean",
-                abstract="Use checked data only.",
+                abstract="Deprecated compatibility parameter. Rook no longer uses pre-checked data selection.",
                 default="0",
                 min_occurs=1,
                 max_occurs=1,
@@ -112,9 +112,6 @@ class AverageByDimension(Process):
         inputs = {
             "collection": collection,
             "output_dir": self.workdir,
-            "pre_checked": parse_wps_input(
-                request.inputs, "pre_checked", default=False
-            ),
             "dims": parse_wps_input(
                 request.inputs, "dims", as_sequence=True, default=None
             ),

--- a/src/rook/processes/wps_average_shape.py
+++ b/src/rook/processes/wps_average_shape.py
@@ -44,7 +44,7 @@ class AverageByShape(Process):
                 "pre_checked",
                 "Pre-Checked",
                 data_type="boolean",
-                abstract="Use checked data only.",
+                abstract="Deprecated compatibility parameter. Rook no longer uses pre-checked data selection.",
                 default="0",
                 min_occurs=1,
                 max_occurs=1,
@@ -111,9 +111,6 @@ class AverageByShape(Process):
         inputs = {
             "collection": collection,
             "output_dir": self.workdir,
-            "pre_checked": parse_wps_input(
-                request.inputs, "pre_checked", default=False
-            ),
             "shape": parse_wps_input(request.inputs, "shape", default=None),
         }
 

--- a/src/rook/processes/wps_average_time.py
+++ b/src/rook/processes/wps_average_time.py
@@ -38,7 +38,7 @@ class AverageByTime(Process):
                 "pre_checked",
                 "Pre-Checked",
                 data_type="boolean",
-                abstract="Use checked data only.",
+                abstract="Deprecated compatibility parameter. Rook no longer uses pre-checked data selection.",
                 default="0",
                 min_occurs=1,
                 max_occurs=1,
@@ -106,9 +106,6 @@ class AverageByTime(Process):
         inputs = {
             "collection": collection,
             "output_dir": self.workdir,
-            "pre_checked": parse_wps_input(
-                request.inputs, "pre_checked", default=False
-            ),
             "freq": parse_wps_input(request.inputs, "freq", default=None),
         }
 

--- a/src/rook/processes/wps_average_weighted.py
+++ b/src/rook/processes/wps_average_weighted.py
@@ -76,7 +76,6 @@ class WeightedAverage(Process):
             "collection": collection,
             "output_dir": self.workdir,
             "dims": ["latitude", "longitude"],
-            "pre_checked": False,
         }
 
         # Let the director manage the processing or redirection to original files

--- a/src/rook/processes/wps_concat.py
+++ b/src/rook/processes/wps_concat.py
@@ -70,7 +70,7 @@ class Concat(Process):
                 "pre_checked",
                 "Pre-Checked",
                 data_type="boolean",
-                abstract="Use checked data only.",
+                abstract="Deprecated compatibility parameter. Rook no longer uses pre-checked data selection.",
                 default="0",
                 min_occurs=1,
                 max_occurs=1,
@@ -137,9 +137,6 @@ class Concat(Process):
         inputs = {
             "collection": collection,
             "output_dir": self.workdir,
-            "pre_checked": parse_wps_input(
-                request.inputs, "pre_checked", default=False
-            ),
             "apply_average": parse_wps_input(
                 request.inputs, "apply_average", default=False
             ),

--- a/src/rook/processes/wps_regrid.py
+++ b/src/rook/processes/wps_regrid.py
@@ -126,7 +126,6 @@ class Regrid(Process):
         inputs = {
             "collection": collection,
             "output_dir": self.workdir,
-            "pre_checked": False,
             "method": parse_wps_input(request.inputs, "method", default="nearest_s2d"),
             "grid": get_grid_param(grid, custom_grid),
             "adaptive_masking_threshold": 0.5,

--- a/src/rook/processes/wps_subset.py
+++ b/src/rook/processes/wps_subset.py
@@ -71,7 +71,7 @@ class Subset(Process):
                 "pre_checked",
                 "Pre-Checked",
                 data_type="boolean",
-                abstract="Use checked data only.",
+                abstract="Deprecated compatibility parameter. Rook no longer uses pre-checked data selection.",
                 default="0",
                 min_occurs=1,
                 max_occurs=1,
@@ -144,9 +144,6 @@ class Subset(Process):
         inputs = {
             "collection": collection,
             "output_dir": self.workdir,
-            "pre_checked": parse_wps_input(
-                request.inputs, "pre_checked", default=False
-            ),
             "original_files": parse_wps_input(
                 request.inputs, "original_files", default=False
             ),

--- a/tests/test_director/test_director.py
+++ b/tests/test_director/test_director.py
@@ -1,6 +1,4 @@
 import pytest
-from pywps.app.exceptions import ProcessError
-
 from clisops.exceptions import InvalidCollection
 
 import rook.director.director as director_mod
@@ -79,13 +77,6 @@ class TestDirectorCMIP6:
             "/ScenarioMIP/INM/INM-CM5-0/ssp245/r1i1p1f1/Amon/rlds/gr1/v20190619"
             "/rlds_Amon_INM-CM5-0_ssp245_r1i1p1f1_gr1_201501-210012.nc"
         ]
-
-    @pytest.mark.skip(reason="not relevant")
-    def test_pre_checked_not_characterised(self):
-        # raise exception
-        inputs = {"pre_checked": True}
-        with pytest.raises(ProcessError):
-            Director(self.collection, inputs)
 
     def test_area_or_level(self):
         # WPS output
@@ -267,11 +258,3 @@ def test_catalog_unknown_collection_raises_invalid_collection(catalog_director):
 
     with pytest.raises(InvalidCollection):
         Director(collection, {})
-
-
-def test_catalog_pre_checked_requires_characterised_data(catalog_director):
-    collection = ["c3s-cmip6.example.dataset"]
-    catalog_director(FakeSearchResult({collection[0]: ["/data/input.nc"]}))
-
-    with pytest.raises(ProcessError, match="Data has not been pre-checked"):
-        Director(collection, {"pre_checked": True})


### PR DESCRIPTION
## Overview

This PR removes the unused `pre_checked` parameter but keeps it as deprecated in the WPS interface.


## Related Issue / Discussion

## Additional Information


