### PR TITLE
prepare refactor of director

### DIFF
--- a/src/rook/director/planning.py
+++ b/src/rook/director/planning.py
@@ -1,4 +1,4 @@
-"""Plan catalog-backed requests before operation execution."""
+"""Plan requests before operation execution."""
 
 from collections import OrderedDict
 from dataclasses import dataclass
@@ -14,26 +14,101 @@ from .alignment import SubsetAlignmentChecker
 
 
 @dataclass(frozen=True)
-class RequestPlan:
-    """Decision values produced before running an operation."""
+class CatalogCollection:
+    """A request source that should be resolved through a project catalog."""
+
+    collection: list[str]
+    project: str
+
+
+@dataclass(frozen=True)
+class DirectDataset:
+    """A request source that should be processed directly without catalog lookup."""
+
+    collection: list[str]
+    project: str
+
+
+@dataclass(frozen=True)
+class WorkflowFiles:
+    """Files produced by an earlier workflow step."""
+
+    files: list[str]
+
+
+@dataclass(frozen=True)
+class ReturnOriginalFiles:
+    """Decision to return catalog file URLs without running an operation."""
 
     project: str
     search_result: object | None = None
-    dataset_sources: tuple[FileMapper, ...] = ()
     original_file_urls: OrderedDict | None = None
 
     @property
     def returns_original_files(self):
         """Return whether this request should bypass processing."""
-        return self.original_file_urls is not None
+        return True
+
+    @property
+    def dataset_sources(self):
+        """Return no prepared operation sources for original-file responses."""
+        return ()
+
+
+@dataclass(frozen=True)
+class RunOperation:
+    """Decision to run an operation on the requested or prepared sources."""
+
+    project: str
+    search_result: object | None = None
+    dataset_sources: tuple[FileMapper, ...] = ()
+
+    @property
+    def returns_original_files(self):
+        """Return whether this request should bypass processing."""
+        return False
+
+    @property
+    def original_file_urls(self):
+        """Return no original file URLs for operation responses."""
+        return None
+
+
+@dataclass(frozen=True)
+class InvalidRequest:
+    """Decision value reserved for explicit invalid-request outcomes."""
+
+    message: str
+
+
+RequestDecision = InvalidRequest | ReturnOriginalFiles | RunOperation
+RequestPlan = RequestDecision
 
 
 def plan_request(collection, inputs):
-    """Return the catalog resolution and original-file plan for a request."""
+    """Return the decision for a request."""
+    source = classify_request_source(collection)
+
+    if isinstance(source, DirectDataset):
+        return RunOperation(project=source.project)
+
+    return plan_catalog_collection(source, inputs)
+
+
+def classify_request_source(collection):
+    """Return the request source represented by a collection argument."""
     project = resolve_project(collection)
 
     if not uses_catalog(project):
-        return RequestPlan(project=project)
+        return DirectDataset(collection=collection, project=project)
+
+    return CatalogCollection(collection=collection, project=project)
+
+
+def plan_catalog_collection(source, inputs):
+    """Return the decision for a catalog collection request."""
+    project = source.project
+    collection = source.collection
 
     search_result = resolve_catalog_search(project, collection, inputs)
 
@@ -92,7 +167,7 @@ def original_files_plan(project, search_result, original_file_urls=None):
     if original_file_urls is None:
         original_file_urls = search_result.download_urls()
 
-    return RequestPlan(
+    return ReturnOriginalFiles(
         project=project,
         search_result=search_result,
         original_file_urls=original_file_urls,
@@ -101,7 +176,7 @@ def original_files_plan(project, search_result, original_file_urls=None):
 
 def operation_plan(project, search_result):
     """Return a plan that runs operation execution."""
-    return RequestPlan(
+    return RunOperation(
         project=project,
         search_result=search_result,
         dataset_sources=dataset_sources_from_search(search_result),

--- a/src/rook/operations/execution.py
+++ b/src/rook/operations/execution.py
@@ -7,6 +7,7 @@ from copy import deepcopy
 from clisops.utils.file_utils import FileMapper, is_file_list
 
 from rook.director import wrap_director
+from rook.director.planning import WorkflowFiles
 from rook.utils.input_utils import (
     clean_inputs,
     fix_parameters,
@@ -51,6 +52,21 @@ def run_regrid(args):
     return regrid(**args).file_uris
 
 
+def prepare_workflow_file_inputs(args, source):
+    """Return operation inputs for files produced by a previous workflow step."""
+    kwargs = deepcopy(args)
+    clean_inputs(kwargs)
+    file_paths = resolve_to_file_paths(source.files)
+    kwargs["collection"] = FileMapper(file_paths)
+    return kwargs
+
+
+def run_workflow_files(args, runner):
+    """Run an operation using previous workflow step output files."""
+    source = WorkflowFiles(files=args["collection"])
+    return runner(prepare_workflow_file_inputs(args, source))
+
+
 class Operator:
     # Sub-classes require "prefix" property
     prefix = NotImplemented
@@ -75,13 +91,7 @@ class Operator:
         runner = self._get_runner()
 
         if is_file_list(collection):
-            # This block is called if this is NOT the first stage of a workflow, and
-            # the collection will be a file list (one or more files)
-            kwargs = deepcopy(args)
-            clean_inputs(kwargs)
-            file_paths = resolve_to_file_paths(args.get("collection"))
-            kwargs["collection"] = FileMapper(file_paths)
-            output_uris = runner(kwargs)  # this needs to be in a list
+            output_uris = run_workflow_files(args, runner)
         else:
             # This block is called when this is the first stage of a workflow
             director = wrap_director(collection, args, runner)

--- a/tests/test_director/test_director.py
+++ b/tests/test_director/test_director.py
@@ -70,6 +70,7 @@ class TestDirectorCMIP6:
         )
         plan = planning_mod.plan_request(self.collection, inputs)
         assert plan.project == "c3s-cmip6"
+        assert isinstance(plan, planning_mod.RunOperation)
 
     def test_original_files(self, catalog_director):
         # original files
@@ -88,6 +89,7 @@ class TestDirectorCMIP6:
         )
         plan = planning_mod.plan_request(self.collection, inputs)
         assert plan.returns_original_files is True
+        assert isinstance(plan, planning_mod.ReturnOriginalFiles)
         assert list(plan.original_file_urls.items())[0][1] == [url]
 
     def test_area_or_level(self, tmp_path, catalog_director):
@@ -178,6 +180,36 @@ def test_catalog_collection_is_resolved_and_processed(tmp_path, catalog_director
     assert "original_files" not in captured["inputs"]
     assert len(captured["inputs"]["collection"]) == 1
     assert captured["inputs"]["collection"][0].dataset_id == collection[0]
+
+
+def test_catalog_collection_source_is_named(catalog_director):
+    collection = ["c3s-cmip6.example.dataset"]
+    catalog_director(FakeSearchResult({collection[0]: ["/data/input.nc"]}))
+
+    source = planning_mod.classify_request_source(collection)
+
+    assert isinstance(source, planning_mod.CatalogCollection)
+    assert source.collection == collection
+    assert source.project == "c3s-cmip6"
+
+
+def test_non_catalog_collection_source_is_direct(monkeypatch):
+    collection = ["CMIP6.CMIP.NCAR.CESM2.amip.r3i1p1f1.Amon.cl.gn.v20190319"]
+    monkeypatch.setattr(
+        planning_mod.config,
+        "get_project_config",
+        lambda _project: {"use_catalog": False},
+    )
+
+    source = planning_mod.classify_request_source(collection)
+    plan = planning_mod.plan_request(collection, {})
+
+    assert isinstance(source, planning_mod.DirectDataset)
+    assert source.collection == collection
+    assert source.project == "cmip6"
+    assert isinstance(plan, planning_mod.RunOperation)
+    assert plan.search_result is None
+    assert plan.dataset_sources == ()
 
 
 def test_wrap_director_returns_request_result(tmp_path, catalog_director):

--- a/tests/test_operations_execution.py
+++ b/tests/test_operations_execution.py
@@ -1,5 +1,6 @@
 from clisops.utils.file_utils import FileMapper
 
+from rook.director.planning import WorkflowFiles
 import rook.operations.execution as execution_mod
 from rook.operations import Operator
 
@@ -79,3 +80,25 @@ def test_later_workflow_step_receives_previous_step_files(tmp_path, monkeypatch)
 
     assert output_uris == ["processed.nc"]
     assert isinstance(operator.runner_inputs["collection"], FileMapper)
+
+
+def test_workflow_file_inputs_are_prepared_explicitly(tmp_path):
+    first = tmp_path / "first.nc"
+    second = tmp_path / "second.nc"
+    first.touch()
+    second.touch()
+    args = {
+        "collection": [first.as_posix(), second.as_posix()],
+        "apply_fixes": True,
+        "original_files": True,
+        "pre_checked": True,
+    }
+    source = WorkflowFiles(files=args["collection"])
+
+    runner_inputs = execution_mod.prepare_workflow_file_inputs(args, source)
+
+    assert isinstance(runner_inputs["collection"], FileMapper)
+    assert "apply_fixes" not in runner_inputs
+    assert "original_files" not in runner_inputs
+    assert "pre_checked" not in runner_inputs
+    assert args["collection"] == [first.as_posix(), second.as_posix()]


### PR DESCRIPTION
## Overview

This PR prepares the new request planning module.

Changes:

- add explicit request source and decision types for request planning
- keep existing director adapter behavior compatible
- move workflow file input preparation behind a named path
- add characterization tests for planner decisions and workflow files

## Related Issue / Discussion

## Additional Information


