### PR TITLE
Replace director wrapper usage with planned request adapter

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -239,13 +239,13 @@ Docs should include:
 Use this as the running progress log for the phase. Tick a box only after the
 corresponding PR has landed.
 
-- [ ] Request outcome characterization tests are in place.
-- [ ] Workflow file inputs are covered by tests and named explicitly.
-- [ ] Request source types are introduced.
-- [ ] Planner decision types are introduced.
+- [x] Request outcome characterization tests are in place.
+- [x] Workflow file inputs are covered by tests and named explicitly.
+- [x] Request source types are introduced.
+- [x] Planner decision types are introduced.
 - [ ] Hard-coded decision rules are isolated behind named predicates or
   policies.
-- [ ] Catalog and original-file planning use the new decision model.
+- [x] Catalog and original-file planning use the new decision model.
 - [ ] `wrap_director` has been replaced or intentionally kept with a documented
   reason.
 - [ ] Dataset-fix policy is centralized, tested, and documented.

--- a/src/rook/director/__init__.py
+++ b/src/rook/director/__init__.py
@@ -1,1 +1,2 @@
+from .director import execute_planned_request as execute_planned_request
 from .director import wrap_director as wrap_director

--- a/src/rook/director/director.py
+++ b/src/rook/director/director.py
@@ -3,9 +3,14 @@ from pywps.app.exceptions import ProcessError
 from .execution import execute_request
 
 
-def wrap_director(collection, inputs, runner):
-    # Ask director whether request should be rejected, use original files or apply WPS process
+def execute_planned_request(collection, inputs, runner):
+    """Plan a request, execute it when needed, and translate WPS errors."""
     try:
         return execute_request(collection, inputs, runner)
     except Exception as e:
         raise ProcessError(f"{e}")
+
+
+def wrap_director(collection, inputs, runner):
+    """Compatibility alias for callers not yet moved to planner naming."""
+    return execute_planned_request(collection, inputs, runner)

--- a/src/rook/operations/execution.py
+++ b/src/rook/operations/execution.py
@@ -6,7 +6,7 @@ from copy import deepcopy
 
 from clisops.utils.file_utils import FileMapper, is_file_list
 
-from rook.director import wrap_director
+from rook.director import execute_planned_request
 from rook.director.planning import WorkflowFiles
 from rook.utils.input_utils import (
     clean_inputs,
@@ -93,9 +93,8 @@ class Operator:
         if is_file_list(collection):
             output_uris = run_workflow_files(args, runner)
         else:
-            # This block is called when this is the first stage of a workflow
-            director = wrap_director(collection, args, runner)
-            output_uris = director.output_uris
+            request_result = execute_planned_request(collection, args, runner)
+            output_uris = request_result.output_uris
 
         return output_uris
 

--- a/src/rook/processes/wps_average_dim.py
+++ b/src/rook/processes/wps_average_dim.py
@@ -4,7 +4,7 @@ import os
 from pywps import FORMATS, ComplexOutput, Format, LiteralInput, Process
 from pywps.app.Common import Metadata
 
-from ..director import wrap_director
+from ..director import execute_planned_request
 from ..operations import run_average_by_dim
 from ..utils.input_utils import parse_wps_input
 from ..utils.metalink_utils import build_metalink
@@ -117,14 +117,14 @@ class AverageByDimension(Process):
             ),
         }
 
-        # Let the director manage the processing or redirection to original files
-        director = wrap_director(collection, inputs, run_average_by_dim)
+        # Plan the request before processing or returning original files
+        request_result = execute_planned_request(collection, inputs, run_average_by_dim)
 
         ml4 = build_metalink(
             "average-dim-result",
             "Averaging by dimension result as NetCDF files.",
             self.workdir,
-            director.output_uris,
+            request_result.output_uris,
         )
 
         populate_response(response, "average", self.workdir, inputs, collection, ml4)

--- a/src/rook/processes/wps_average_shape.py
+++ b/src/rook/processes/wps_average_shape.py
@@ -4,7 +4,7 @@ import os
 from pywps import FORMATS, ComplexInput, ComplexOutput, Format, LiteralInput, Process
 from pywps.app.Common import Metadata
 
-from ..director import wrap_director
+from ..director import execute_planned_request
 from ..operations import run_average_by_shape
 from ..utils.input_utils import parse_wps_input
 from ..utils.metalink_utils import build_metalink
@@ -114,14 +114,14 @@ class AverageByShape(Process):
             "shape": parse_wps_input(request.inputs, "shape", default=None),
         }
 
-        # Let the director manage the processing or redirection to original files
-        director = wrap_director(collection, inputs, run_average_by_shape)
+        # Plan the request before processing or returning original files
+        request_result = execute_planned_request(collection, inputs, run_average_by_shape)
 
         ml4 = build_metalink(
             "average-shape-result",
             "Averaging by shape result as NetCDF files.",
             self.workdir,
-            director.output_uris,
+            request_result.output_uris,
         )
 
         populate_response(

--- a/src/rook/processes/wps_average_time.py
+++ b/src/rook/processes/wps_average_time.py
@@ -4,7 +4,7 @@ import os
 from pywps import FORMATS, ComplexOutput, Format, LiteralInput, Process
 from pywps.app.Common import Metadata
 
-from ..director import wrap_director
+from ..director import execute_planned_request
 from ..operations import run_average_by_time
 from ..utils.input_utils import parse_wps_input
 from ..utils.metalink_utils import build_metalink
@@ -109,14 +109,14 @@ class AverageByTime(Process):
             "freq": parse_wps_input(request.inputs, "freq", default=None),
         }
 
-        # Let the director manage the processing or redirection to original files
-        director = wrap_director(collection, inputs, run_average_by_time)
+        # Plan the request before processing or returning original files
+        request_result = execute_planned_request(collection, inputs, run_average_by_time)
 
         ml4 = build_metalink(
             "average-time-result",
             "Averaging by time result as NetCDF files.",
             self.workdir,
-            director.output_uris,
+            request_result.output_uris,
         )
 
         populate_response(

--- a/src/rook/processes/wps_average_weighted.py
+++ b/src/rook/processes/wps_average_weighted.py
@@ -3,7 +3,7 @@ import logging
 from pywps import FORMATS, ComplexOutput, Format, LiteralInput, Process
 from pywps.app.Common import Metadata
 
-from ..director import wrap_director
+from ..director import execute_planned_request
 from ..operations import run_weighted_average
 from ..utils.input_utils import parse_wps_input
 from ..utils.metalink_utils import build_metalink
@@ -78,14 +78,14 @@ class WeightedAverage(Process):
             "dims": ["latitude", "longitude"],
         }
 
-        # Let the director manage the processing or redirection to original files
-        director = wrap_director(collection, inputs, run_weighted_average)
+        # Plan the request before processing or returning original files
+        request_result = execute_planned_request(collection, inputs, run_weighted_average)
 
         ml4 = build_metalink(
             "weighted-average-result",
             "Weighted averaging result as NetCDF files.",
             self.workdir,
-            director.output_uris,
+            request_result.output_uris,
         )
 
         populate_response(

--- a/src/rook/processes/wps_concat.py
+++ b/src/rook/processes/wps_concat.py
@@ -3,7 +3,7 @@ import logging
 from pywps import FORMATS, ComplexOutput, Format, LiteralInput, Process
 from pywps.app.Common import Metadata
 
-from ..director import wrap_director
+from ..director import execute_planned_request
 from ..operations import run_concat
 from ..utils.input_utils import parse_wps_input
 from ..utils.metalink_utils import build_metalink
@@ -149,14 +149,14 @@ class Concat(Process):
             ),
         }
 
-        # Let the director manage the processing or redirection to original files
-        director = wrap_director(collection, inputs, run_concat)
+        # Plan the request before processing or returning original files
+        request_result = execute_planned_request(collection, inputs, run_concat)
 
         ml4 = build_metalink(
             "concat-result",
             "Concat result as NetCDF files.",
             self.workdir,
-            director.output_uris,
+            request_result.output_uris,
         )
 
         populate_response(response, "concat", self.workdir, inputs, collection, ml4)

--- a/src/rook/processes/wps_regrid.py
+++ b/src/rook/processes/wps_regrid.py
@@ -3,7 +3,7 @@ import logging
 from pywps import FORMATS, ComplexOutput, Format, LiteralInput, Process
 from pywps.app.Common import Metadata
 
-from ..director import wrap_director
+from ..director import execute_planned_request
 from ..operations import run_regrid
 from ..utils.input_utils import parse_wps_input, get_grid_param
 from ..utils.metalink_utils import build_metalink
@@ -132,14 +132,14 @@ class Regrid(Process):
         }
         # print(inputs)
 
-        # Let the director manage the processing or redirection to original files
-        director = wrap_director(collection, inputs, run_regrid)
+        # Plan the request before processing or returning original files
+        request_result = execute_planned_request(collection, inputs, run_regrid)
 
         ml4 = build_metalink(
             "regrid-result",
             "regrid result as NetCDF files.",
             self.workdir,
-            director.output_uris,
+            request_result.output_uris,
         )
 
         populate_response(response, "regrid", self.workdir, inputs, collection, ml4)

--- a/src/rook/processes/wps_subset.py
+++ b/src/rook/processes/wps_subset.py
@@ -3,7 +3,7 @@ import logging
 from pywps import FORMATS, ComplexOutput, Format, LiteralInput, Process
 from pywps.app.Common import Metadata
 
-from ..director import wrap_director
+from ..director import execute_planned_request
 from ..operations import run_subset
 from ..utils.input_utils import parse_wps_input
 from ..utils.metalink_utils import build_metalink
@@ -155,14 +155,14 @@ class Subset(Process):
             "area": parse_wps_input(request.inputs, "area", default=None),
         }
 
-        # Let the director manage the processing or redirection to original files
-        director = wrap_director(collection, inputs, run_subset)
+        # Plan the request before processing or returning original files
+        request_result = execute_planned_request(collection, inputs, run_subset)
 
         ml4 = build_metalink(
             "subset-result",
             "Subsetting result as NetCDF files.",
             self.workdir,
-            director.output_uris,
+            request_result.output_uris,
         )
 
         populate_response(response, "subset", self.workdir, inputs, collection, ml4)

--- a/tests/test_director/test_director.py
+++ b/tests/test_director/test_director.py
@@ -2,7 +2,7 @@ import pytest
 from clisops.exceptions import InvalidCollection
 
 import rook.director.planning as planning_mod
-from rook.director import wrap_director
+from rook.director import execute_planned_request, wrap_director
 
 
 class FakeSearchResult:
@@ -160,7 +160,7 @@ def test_catalog_collection_is_resolved_and_processed(tmp_path, catalog_director
         captured["inputs"] = runner_inputs
         return ["processed.nc"]
 
-    result = wrap_director(collection, inputs, runner)
+    result = execute_planned_request(collection, inputs, runner)
 
     assert catalog.search_kwargs == {
         "collection": collection,
@@ -212,7 +212,22 @@ def test_non_catalog_collection_source_is_direct(monkeypatch):
     assert plan.dataset_sources == ()
 
 
-def test_wrap_director_returns_request_result(tmp_path, catalog_director):
+def test_execute_planned_request_returns_request_result(tmp_path, catalog_director):
+    collection = ["c3s-cmip6.example.dataset"]
+    source = tmp_path / "input.nc"
+    source.touch()
+    catalog_director(FakeSearchResult({collection[0]: [source.as_posix()]}))
+
+    result = execute_planned_request(
+        collection, {"area": "0,0,10,10"}, lambda _inputs: ["out.nc"]
+    )
+
+    assert result.output_uris == ["out.nc"]
+    assert result.use_original_files is False
+    assert result.dataset_sources[0].dataset_id == collection[0]
+
+
+def test_wrap_director_alias_returns_request_result(tmp_path, catalog_director):
     collection = ["c3s-cmip6.example.dataset"]
     source = tmp_path / "input.nc"
     source.touch()
@@ -221,8 +236,6 @@ def test_wrap_director_returns_request_result(tmp_path, catalog_director):
     result = wrap_director(collection, {"area": "0,0,10,10"}, lambda _inputs: ["out.nc"])
 
     assert result.output_uris == ["out.nc"]
-    assert result.use_original_files is False
-    assert result.dataset_sources[0].dataset_id == collection[0]
 
 
 def test_catalog_original_files_are_returned_when_requested(catalog_director):
@@ -234,7 +247,7 @@ def test_catalog_original_files_are_returned_when_requested(catalog_director):
     )
     catalog_director(result)
 
-    result = wrap_director(
+    result = execute_planned_request(
         collection,
         {"original_files": True},
         lambda _inputs: pytest.fail("runner should not be called"),
@@ -265,7 +278,7 @@ def test_catalog_aligned_subset_returns_matching_original_files(
 
     monkeypatch.setattr(planning_mod, "SubsetAlignmentChecker", AlignedFakeAlignment)
 
-    result = wrap_director(
+    result = execute_planned_request(
         collection,
         {"time": "2001-01-01/2001-12-31"},
         lambda _inputs: pytest.fail("runner should not be called"),
@@ -293,7 +306,7 @@ def test_catalog_non_aligned_subset_is_processed(
 
     monkeypatch.setattr(planning_mod, "SubsetAlignmentChecker", NotAlignedFakeAlignment)
 
-    result = wrap_director(
+    result = execute_planned_request(
         collection, {"time": "2001-02-01/2001-02-28"}, lambda _inputs: ["subset.nc"]
     )
 

--- a/tests/test_operations_execution.py
+++ b/tests/test_operations_execution.py
@@ -20,8 +20,8 @@ class RecordingOperator(Operator):
         return runner
 
 
-def fail_director(*_args, **_kwargs):
-    raise AssertionError("director should not be called")
+def fail_planned_request_executor(*_args, **_kwargs):
+    raise AssertionError("planned request executor should not be called")
 
 
 def test_run_regrid_normalizes_custom_grid(monkeypatch):
@@ -49,7 +49,9 @@ def test_direct_file_collection_is_processed_without_director(tmp_path, monkeypa
     source = tmp_path / "source.nc"
     source.touch()
     operator = RecordingOperator(tmp_path)
-    monkeypatch.setattr(execution_mod, "wrap_director", fail_director)
+    monkeypatch.setattr(
+        execution_mod, "execute_planned_request", fail_planned_request_executor
+    )
 
     output_uris = operator.call(
         {
@@ -74,7 +76,9 @@ def test_later_workflow_step_receives_previous_step_files(tmp_path, monkeypatch)
     first.touch()
     second.touch()
     operator = RecordingOperator(tmp_path)
-    monkeypatch.setattr(execution_mod, "wrap_director", fail_director)
+    monkeypatch.setattr(
+        execution_mod, "execute_planned_request", fail_planned_request_executor
+    )
 
     output_uris = operator.call({"collection": [first.as_posix(), second.as_posix()]})
 


### PR DESCRIPTION
## Overview

This PR mainly does rename "director" into "request plan".

Changes:

- add execute_planned_request as the named WPS planning/execution adapter
- move WPS processes and operation execution off wrap_director
- keep wrap_director as a compatibility alias
- update director tests for the new adapter name
- tick completed cleanup-phase TODO items from the previous PR

## Related Issue / Discussion

## Additional Information


