### PR TITLE
Isolate planner decision policies

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -246,7 +246,7 @@ corresponding PR has landed.
 - [ ] Hard-coded decision rules are isolated behind named predicates or
   policies.
 - [x] Catalog and original-file planning use the new decision model.
-- [ ] `wrap_director` has been replaced or intentionally kept with a documented
+- [x] `wrap_director` has been replaced or intentionally kept with a documented
   reason.
 - [ ] Dataset-fix policy is centralized, tested, and documented.
 - [ ] Operation adapters have been simplified around clisops.

--- a/src/rook/director/planning.py
+++ b/src/rook/director/planning.py
@@ -13,6 +13,10 @@ from rook.catalog import get_catalog
 from .alignment import SubsetAlignmentChecker
 
 
+ORIGINAL_FILE_PROJECTS = frozenset({"c3s-ipcc-atlas"})
+PROCESSING_REQUIRED_INPUTS = frozenset({"dims", "freq", "grid"})
+
+
 @dataclass(frozen=True)
 class CatalogCollection:
     """A request source that should be resolved through a project catalog."""
@@ -112,10 +116,10 @@ def plan_catalog_collection(source, inputs):
 
     search_result = resolve_catalog_search(project, collection, inputs)
 
-    if returns_original_catalog_files(project, inputs):
+    if may_return_original_files(project, inputs):
         return original_files_plan(project, search_result)
 
-    if operation_requires_processing(inputs):
+    if requires_processing(inputs):
         return operation_plan(project, search_result)
 
     return aligned_subset_plan(project, search_result, inputs)
@@ -157,9 +161,9 @@ def validate_search_result(search_result, collection):
         raise InvalidCollection()
 
 
-def returns_original_catalog_files(project, inputs):
-    """Return whether original catalog files should be returned immediately."""
-    return requests_original_files(inputs) or project == "c3s-ipcc-atlas"
+def may_return_original_files(project, inputs):
+    """Return whether catalog data may be returned without processing."""
+    return requests_original_files(inputs) or project_returns_original_files(project)
 
 
 def original_files_plan(project, search_result, original_file_urls=None):
@@ -198,9 +202,23 @@ def requests_original_files(inputs):
     return bool(inputs.get("original_files"))
 
 
-def operation_requires_processing(inputs):
-    """Return whether the operation changes data and must run."""
-    return "dims" in inputs or "freq" in inputs or "grid" in inputs
+def project_returns_original_files(project):
+    """Return whether a project currently bypasses processing by policy."""
+    return project in ORIGINAL_FILE_PROJECTS
+
+
+def requires_processing(inputs):
+    """Return whether the requested operation changes data and must run."""
+    return has_processing_required_input(inputs)
+
+
+def has_processing_required_input(inputs):
+    """Return whether current request parameters imply changed output data.
+
+    This preserves the existing operation detection rule while keeping the
+    hard-coded parameter names out of the main planning flow.
+    """
+    return bool(PROCESSING_REQUIRED_INPUTS.intersection(inputs))
 
 
 def aligned_original_file_urls(search_result, inputs):

--- a/tests/test_director/test_director.py
+++ b/tests/test_director/test_director.py
@@ -257,6 +257,25 @@ def test_catalog_original_files_are_returned_when_requested(catalog_director):
     assert result.output_uris == [download_url]
 
 
+def test_catalog_original_files_are_returned_for_project_policy(catalog_director):
+    collection = ["c3s-ipcc-atlas.example.dataset"]
+    download_url = "https://example.test/data/atlas-input.nc"
+    result = FakeSearchResult(
+        {collection[0]: ["/data/atlas-input.nc"]},
+        download_records={collection[0]: [download_url]},
+    )
+    catalog_director(result)
+
+    result = execute_planned_request(
+        collection,
+        {},
+        lambda _inputs: pytest.fail("runner should not be called"),
+    )
+
+    assert result.use_original_files is True
+    assert result.output_uris == [download_url]
+
+
 def test_catalog_aligned_subset_returns_matching_original_files(
     catalog_director, monkeypatch
 ):
@@ -338,6 +357,14 @@ def test_catalog_operations_that_change_data_are_always_processed(
 
     assert plan.returns_original_files is False
     assert plan.original_file_urls is None
+
+
+def test_processing_required_inputs_are_named_policy():
+    assert planning_mod.PROCESSING_REQUIRED_INPUTS == frozenset(
+        {"dims", "freq", "grid"}
+    )
+    assert planning_mod.requires_processing({"dims": "time"}) is True
+    assert planning_mod.requires_processing({"area": "0,0,10,10"}) is False
 
 
 def test_catalog_unknown_collection_raises_invalid_collection(catalog_director):


### PR DESCRIPTION
## Overview

This PR hides hard-code values for request plan decisions behind meaningful names.

Changes:

- add named planner policies for original-file project shortcuts
- add named planner policies for request parameters that require processing
- update catalog planning to use policy predicates instead of inline checks
- add focused tests for atlas original-file behavior and processing-required inputs
- tick the landed wrap_director cleanup TODO item

## Related Issue / Discussion

## Additional Information


