### PR TITLE
Use DatasetSource for prepared catalog inputs

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -243,7 +243,7 @@ corresponding PR has landed.
 - [x] Workflow file inputs are covered by tests and named explicitly.
 - [x] Request source types are introduced.
 - [x] Planner decision types are introduced.
-- [ ] Hard-coded decision rules are isolated behind named predicates or
+- [x] Hard-coded decision rules are isolated behind named predicates or
   policies.
 - [x] Catalog and original-file planning use the new decision model.
 - [x] `wrap_director` has been replaced or intentionally kept with a documented

--- a/TODO.md
+++ b/TODO.md
@@ -234,6 +234,14 @@ Docs should include:
 8. Clean up `rook.workflow` after the operation path is simpler.
 9. Refresh the Mermaid diagram and architecture docs.
 
+## Follow-Up Notes
+
+- Keep the immediate mini ESGF test-data fix inside Rook and leave clisops
+  untouched. The current fixture should use the existing clisops/Pooch `stratus`
+  helper, but the Rook-side selection of required files should be made a little
+  nicer: easier to read, named by test-data purpose, and documented as a
+  temporary bridge until mini-esgf-data is replaced in a later phase.
+
 ## Phase Checklist
 
 Use this as the running progress log for the phase. Tick a box only after the

--- a/src/rook/director/planning.py
+++ b/src/rook/director/planning.py
@@ -5,10 +5,10 @@ from dataclasses import dataclass
 
 from clisops.exceptions import InvalidCollection
 from clisops.project_utils import get_project_name
-from clisops.utils.file_utils import FileMapper
 
 from rook import config
 from rook.catalog import get_catalog
+from rook.io.datasets import DatasetSource
 
 from .alignment import SubsetAlignmentChecker
 
@@ -65,7 +65,7 @@ class RunOperation:
 
     project: str
     search_result: object | None = None
-    dataset_sources: tuple[FileMapper, ...] = ()
+    dataset_sources: tuple[DatasetSource, ...] = ()
 
     @property
     def returns_original_files(self):
@@ -239,12 +239,8 @@ def aligned_original_file_urls(search_result, inputs):
 
 
 def dataset_sources_from_search(search_result):
-    """Return file mappers for catalog-resolved operation inputs."""
-    dataset_sources = []
-
-    for ds_id, file_uris in search_result.files().items():
-        file_mapper = FileMapper(file_uris)
-        file_mapper.dataset_id = ds_id
-        dataset_sources.append(file_mapper)
-
-    return tuple(dataset_sources)
+    """Return normalized sources for catalog-resolved operation inputs."""
+    return tuple(
+        DatasetSource(dataset_id=ds_id, paths=file_uris)
+        for ds_id, file_uris in search_result.files().items()
+    )

--- a/src/rook/operations/average.py
+++ b/src/rook/operations/average.py
@@ -3,9 +3,9 @@
 from clisops.ops.average import average_over_dims as clisops_average_over_dims
 from clisops.ops.average import average_shape as clisops_average_shape
 from clisops.ops.average import average_time as clisops_average_time
-from clisops.parameter import collection_parameter, dimension_parameter
+from clisops.parameter import dimension_parameter
 
-from .base import Operation
+from .base import Operation, resolve_collection
 
 __all__ = ["Average", "average_over_dims", "average_shape", "average_time"]
 
@@ -13,9 +13,8 @@ __all__ = ["Average", "average_over_dims", "average_shape", "average_time"]
 class Average(Operation):
     def _resolve_params(self, collection, **params):
         dims = dimension_parameter.DimensionParameter(params.get("dims"))
-        collection = collection_parameter.CollectionParameter(collection)
 
-        self.collection = collection
+        self.collection = resolve_collection(collection)
         self.params = {
             "dims": dims,
             "ignore_undetected_dims": params.get("ignore_undetected_dims"),
@@ -40,9 +39,8 @@ def average_over_dims(
 class AverageShape(Operation):
     def _resolve_params(self, collection, **params):
         shape = params.get("shape")
-        collection = collection_parameter.CollectionParameter(collection)
 
-        self.collection = collection
+        self.collection = resolve_collection(collection)
         self.params = {
             "shape": shape,
             "variable": params.get("variable"),
@@ -67,9 +65,8 @@ def average_shape(
 class AverageTime(Operation):
     def _resolve_params(self, collection, **params):
         freq = params.get("freq")
-        collection = collection_parameter.CollectionParameter(collection)
 
-        self.collection = collection
+        self.collection = resolve_collection(collection)
         self.params = {
             "freq": freq,
         }

--- a/src/rook/operations/base.py
+++ b/src/rook/operations/base.py
@@ -1,9 +1,20 @@
 """Base class for operation execution."""
 
+from dataclasses import dataclass
+
 from clisops.parameter import collection_parameter
+
+from rook.io.datasets import DatasetSource
 
 from . import consolidate, normalise
 from .processor import process
+
+
+@dataclass(frozen=True)
+class PreparedCollection:
+    """Collection wrapper for already-resolved dataset sources."""
+
+    value: tuple[DatasetSource, ...]
 
 
 class Operation:
@@ -26,7 +37,10 @@ class Operation:
         self._consolidate_collection()
 
     def _resolve_params(self, collection, **params):
-        self.collection = collection_parameter.CollectionParameter(collection)
+        if is_prepared_dataset_collection(collection):
+            self.collection = PreparedCollection(value=tuple(collection))
+        else:
+            self.collection = collection_parameter.CollectionParameter(collection)
         self.params = params
 
     def _consolidate_collection(self):
@@ -61,3 +75,10 @@ class Operation:
             )
 
         return rs
+
+
+def is_prepared_dataset_collection(collection):
+    """Return whether a collection contains normalized dataset sources."""
+    return bool(collection) and isinstance(collection, (list, tuple)) and all(
+        isinstance(item, DatasetSource) for item in collection
+    )

--- a/src/rook/operations/base.py
+++ b/src/rook/operations/base.py
@@ -37,10 +37,7 @@ class Operation:
         self._consolidate_collection()
 
     def _resolve_params(self, collection, **params):
-        if is_prepared_dataset_collection(collection):
-            self.collection = PreparedCollection(value=tuple(collection))
-        else:
-            self.collection = collection_parameter.CollectionParameter(collection)
+        self.collection = resolve_collection(collection)
         self.params = params
 
     def _consolidate_collection(self):
@@ -82,3 +79,10 @@ def is_prepared_dataset_collection(collection):
     return bool(collection) and isinstance(collection, (list, tuple)) and all(
         isinstance(item, DatasetSource) for item in collection
     )
+
+
+def resolve_collection(collection):
+    """Return a collection value suitable for operation consolidation."""
+    if is_prepared_dataset_collection(collection):
+        return PreparedCollection(value=tuple(collection))
+    return collection_parameter.CollectionParameter(collection)

--- a/src/rook/operations/consolidate.py
+++ b/src/rook/operations/consolidate.py
@@ -139,6 +139,10 @@ def consolidate(collection, **kwargs):
     catalogs = {}
 
     for dset in collection:
+        if isinstance(dset, DatasetSource):
+            sources.append(dset)
+            continue
+
         if not isinstance(dset, FileMapper) and _bypasses_catalog(dset):
             sources.append(DatasetSource(dataset_id=None, paths=dset))
             continue

--- a/src/rook/operations/regrid.py
+++ b/src/rook/operations/regrid.py
@@ -1,18 +1,15 @@
 """Regrid operation."""
 
 from clisops.ops.regrid import regrid as clisops_regrid
-from clisops.parameter import collection_parameter
 
-from .base import Operation
+from .base import Operation, resolve_collection
 
 __all__ = ["Regrid", "regrid"]
 
 
 class Regrid(Operation):
     def _resolve_params(self, collection, **params):
-        collection = collection_parameter.CollectionParameter(collection)
-
-        self.collection = collection
+        self.collection = resolve_collection(collection)
         self.params = {
             "method": params.get("method"),
             "adaptive_masking_threshold": params.get("adaptive_masking_threshold"),

--- a/src/rook/operations/subset.py
+++ b/src/rook/operations/subset.py
@@ -1,9 +1,14 @@
 """Subset operation."""
 
 from clisops.ops.subset import subset as clisops_subset
-from clisops.parameter import parameterise
+from clisops.parameter import (
+    area_parameter,
+    level_parameter,
+    time_components_parameter,
+    time_parameter,
+)
 
-from .base import Operation
+from .base import Operation, resolve_collection
 from . import normalise
 
 __all__ = ["Subset", "subset"]
@@ -11,16 +16,15 @@ __all__ = ["Subset", "subset"]
 
 class Subset(Operation):
     def _resolve_params(self, collection, **params):
-        parameters = parameterise(
-            collection=collection,
-            time=params.get("time"),
-            area=params.get("area"),
-            level=params.get("level"),
-            time_components=params.get("time_components"),
-        )
-
-        self.collection = parameters.pop("collection")
-        self.params = parameters
+        self.collection = resolve_collection(collection)
+        self.params = {
+            "area": area_parameter.AreaParameter(params.get("area")),
+            "level": level_parameter.LevelParameter(params.get("level")),
+            "time": time_parameter.TimeParameter(params.get("time")),
+            "time_components": time_components_parameter.TimeComponentsParameter(
+                params.get("time_components")
+            ),
+        }
 
     def calculate(self):
         config = {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,11 +6,12 @@ import requests
 import shutil
 
 import pytest
+from filelock import FileLock
 from clisops.utils.testing import (
     ESGF_TEST_DATA_CACHE_DIR,
     ESGF_TEST_DATA_REPO_URL,
     ESGF_TEST_DATA_VERSION,
-    gather_testing_data,
+    load_registry,
 )
 from clisops.utils.testing import stratus as _stratus
 from jinja2 import Template
@@ -25,6 +26,40 @@ xpath_ns = get_xpath_ns(VERSION)
 TESTS_HOME = Path(__file__).parent.absolute()
 ROOCS_CFG = TESTS_HOME.joinpath(".roocs.ini")
 PYWPS_CFG = TESTS_HOME.joinpath("pywps.cfg")
+
+TEST_DATA_FILE_PATTERNS = (
+    "badc/cmip5/data/cmip5/output1/ICHEC/EC-EARTH/historical/mon/atmos/Amon/r1i1p1/latest/tas/",
+    "badc/cmip5/data/cmip5/output1/MOHC/HadGEM2-ES/historical/mon/atmos/Amon/r1i1p1/latest/tas/",
+    "badc/cmip6/data/CMIP6/CMIP/IPSL/IPSL-CM6A-LR/historical/r1i1p1f1/Amon/rlds/gr/v20180803/",
+    "badc/cmip6/data/CMIP6/CMIP/MPI-M/MPI-ESM1-2-HR/historical/r1i1p1f1/Amon/tasmin/gn/v20190710/",
+    "badc/cmip6/data/CMIP6/CMIP/MPI-M/MPI-ESM1-2-HR/historical/r1i1p1f1/SImon/siconc/gn/",
+    "badc/cmip6/data/CMIP6/DCPP/MOHC/HadGEM3-GC31-MM/",
+    "badc/cmip6/data/CMIP6/ScenarioMIP/INM/INM-CM5-0/ssp245/r1i1p1f1/Amon/rlds/gr1/v20190619/",
+    "badc/cmip6/data/CMIP6/ScenarioMIP/NCC/NorESM2-MM/",
+    "gws/nopw/j04/cp4cds1_vol1/data/c3s-cmip5/output1/ICHEC/EC-EARTH/historical/day/atmos/day/r1i1p1/tas/v20131231/",
+    "pool/data/c3s-cica-atlas/",
+)
+
+
+def required_test_data_files():
+    registry = load_registry(
+        branch=ESGF_TEST_DATA_VERSION,
+        repo=ESGF_TEST_DATA_REPO_URL,
+    )
+    files = {
+        filename
+        for filename in registry
+        if filename.startswith(TEST_DATA_FILE_PATTERNS)
+    }
+    return sorted(files)
+
+
+def missing_test_data_files(base_dir):
+    return [
+        filename
+        for filename in required_test_data_files()
+        if not base_dir.joinpath(filename).exists()
+    ]
 
 
 @pytest.fixture(scope="session")
@@ -151,17 +186,33 @@ def get_output():
 @pytest.fixture(scope="session", autouse=True)
 def load_test_data(stratus, write_roocs_cfg):
     """Ensure that the required test data repository has been cloned to the cache directory within the home directory."""
-    repositories = {
-        "stratus": {
-            "worker_cache_dir": stratus.path,
-            "repo": ESGF_TEST_DATA_REPO_URL,
-            "branch": ESGF_TEST_DATA_VERSION,
-            "cache_dir": ESGF_TEST_DATA_CACHE_DIR,
-        },
-    }
+    cache_dir = Path(ESGF_TEST_DATA_CACHE_DIR)
+    marker = cache_dir.joinpath(ESGF_TEST_DATA_VERSION, ".rook_data_ready")
+    lock = FileLock(cache_dir.joinpath(".rook_data.lock"))
+    required_files = required_test_data_files()
 
-    for repo in repositories.values():
-        gather_testing_data(worker_id="master", **repo)
+    cache_dir.mkdir(exist_ok=True, parents=True)
+    with lock:
+        if marker.exists() and not missing_test_data_files(stratus.path):
+            return
+
+        failed_files = []
+        for filename in required_files:
+            try:
+                stratus.fetch(filename)
+            except requests.exceptions.HTTPError:
+                failed_files.append(filename)
+
+        missing_files = missing_test_data_files(stratus.path)
+        if failed_files or missing_files:
+            problem_files = sorted(set(failed_files + missing_files))
+            raise RuntimeError(
+                "Could not prepare required mini ESGF test data: "
+                f"{problem_files}"
+            )
+
+        marker.parent.mkdir(exist_ok=True, parents=True)
+        marker.touch()
 
 
 def download_file(url, tmp_path):

--- a/tests/test_director/test_director.py
+++ b/tests/test_director/test_director.py
@@ -3,6 +3,7 @@ from clisops.exceptions import InvalidCollection
 
 import rook.director.planning as planning_mod
 from rook.director import execute_planned_request, wrap_director
+from rook.io.datasets import DatasetSource
 
 
 class FakeSearchResult:
@@ -169,6 +170,7 @@ def test_catalog_collection_is_resolved_and_processed(tmp_path, catalog_director
     }
     assert result.use_original_files is False
     assert len(result.plan.dataset_sources) == 1
+    assert isinstance(result.plan.dataset_sources[0], DatasetSource)
     assert result.plan.dataset_sources[0].dataset_id == collection[0]
     assert result.output_uris == ["processed.nc"]
     assert inputs == {
@@ -179,6 +181,7 @@ def test_catalog_collection_is_resolved_and_processed(tmp_path, catalog_director
     assert "pre_checked" not in captured["inputs"]
     assert "original_files" not in captured["inputs"]
     assert len(captured["inputs"]["collection"]) == 1
+    assert isinstance(captured["inputs"]["collection"][0], DatasetSource)
     assert captured["inputs"]["collection"][0].dataset_id == collection[0]
 
 

--- a/tests/test_operations_execution.py
+++ b/tests/test_operations_execution.py
@@ -1,8 +1,10 @@
 from clisops.utils.file_utils import FileMapper
 
 from rook.director.planning import WorkflowFiles
+from rook.io.datasets import DatasetSource
 import rook.operations.execution as execution_mod
 from rook.operations import Operator
+from rook.operations.base import Operation, is_prepared_dataset_collection
 
 
 class RecordingOperator(Operator):
@@ -18,6 +20,11 @@ class RecordingOperator(Operator):
             return ["processed.nc"]
 
         return runner
+
+
+class RecordingOperation(Operation):
+    def get_operation_callable(self):
+        raise NotImplementedError
 
 
 def fail_planned_request_executor(*_args, **_kwargs):
@@ -106,3 +113,21 @@ def test_workflow_file_inputs_are_prepared_explicitly(tmp_path):
     assert "original_files" not in runner_inputs
     assert "pre_checked" not in runner_inputs
     assert args["collection"] == [first.as_posix(), second.as_posix()]
+
+
+def test_operation_accepts_prepared_dataset_sources(monkeypatch):
+    prepared = DatasetSource(
+        dataset_id="c3s-cmip6.example.dataset",
+        paths="/data/c3s-cmip6.example.dataset.nc",
+    )
+    monkeypatch.setattr(
+        "rook.operations.base.consolidate.consolidate",
+        lambda collection, **_kwargs: collection.value,
+    )
+
+    assert is_prepared_dataset_collection([prepared]) is True
+    assert is_prepared_dataset_collection([]) is False
+
+    operation = RecordingOperation(collection=[prepared])
+
+    assert operation.collection == (prepared,)

--- a/tests/test_operations_execution.py
+++ b/tests/test_operations_execution.py
@@ -3,8 +3,11 @@ from clisops.utils.file_utils import FileMapper
 from rook.director.planning import WorkflowFiles
 from rook.io.datasets import DatasetSource
 import rook.operations.execution as execution_mod
+from rook.operations.average import Average, AverageShape, AverageTime
 from rook.operations import Operator
 from rook.operations.base import Operation, is_prepared_dataset_collection
+from rook.operations.regrid import Regrid
+from rook.operations.subset import Subset
 
 
 class RecordingOperator(Operator):
@@ -131,3 +134,25 @@ def test_operation_accepts_prepared_dataset_sources(monkeypatch):
     operation = RecordingOperation(collection=[prepared])
 
     assert operation.collection == (prepared,)
+
+
+def test_operation_wrappers_accept_prepared_dataset_sources(monkeypatch):
+    prepared = DatasetSource(
+        dataset_id="c3s-cmip6.example.dataset",
+        paths="/data/c3s-cmip6.example.dataset.nc",
+    )
+    monkeypatch.setattr(
+        "rook.operations.base.consolidate.consolidate",
+        lambda collection, **_kwargs: collection.value,
+    )
+
+    operations = [
+        Subset(collection=[prepared], time="2015-01-01/2015-12-30"),
+        Average(collection=[prepared], dims=["time"]),
+        AverageShape(collection=[prepared], shape="shape.geojson"),
+        AverageTime(collection=[prepared], freq="year"),
+        Regrid(collection=[prepared], grid="1deg"),
+    ]
+
+    for operation in operations:
+        assert operation.collection == (prepared,)

--- a/tests/test_ops_consolidate.py
+++ b/tests/test_ops_consolidate.py
@@ -84,6 +84,22 @@ def test_consolidate_preserves_dataset_id_from_file_mapper(tmp_path):
     )
 
 
+def test_consolidate_preserves_prepared_dataset_source(monkeypatch):
+    def fail_lookup(*_args, **_kwargs):
+        raise AssertionError("Prepared dataset sources should not be resolved again")
+
+    monkeypatch.setattr(consolidate, "get_project_name", fail_lookup)
+    monkeypatch.setattr(consolidate, "get_catalog", fail_lookup)
+    monkeypatch.setattr(consolidate, "dset_to_filepaths", fail_lookup)
+
+    prepared = DatasetSource(
+        dataset_id="c3s-cmip6.example.dataset",
+        paths="/data/c3s-cmip6.example.dataset.nc",
+    )
+
+    assert consolidate.consolidate(DummyCollection([prepared])) == (prepared,)
+
+
 def test_consolidate_catalog_files_can_use_s3_base_dir(monkeypatch):
     class DummyCatalog:
         def search(self, collection, time):


### PR DESCRIPTION
## Overview

This PR uses `DatasetSource` for a request plan.

Changes:

- return DatasetSource values from catalog request planning
- stop attaching dataset_id dynamically to FileMapper in the planner
- allow operations to accept already-prepared DatasetSource collections
- preserve prepared DatasetSource values in consolidate without re-resolving
- add focused tests for prepared source flow and TODO progress

## Related Issue / Discussion

## Additional Information


