### PR TITLE
fix decadal smoke test

### DIFF
--- a/src/rook/operations/concat.py
+++ b/src/rook/operations/concat.py
@@ -5,7 +5,6 @@ import xarray as xr
 
 from clisops.core.average import average_over_dims as average
 from clisops.ops import subset
-from clisops.parameter import collection_parameter
 from clisops.parameter import dimension_parameter
 from clisops.parameter import time_components_parameter
 from clisops.parameter import time_parameter
@@ -15,7 +14,7 @@ from clisops.utils.dataset_utils import open_xr_dataset
 from rook.utils.decadal_fixes import apply_decadal_fixes, decadal_fix_calendar
 
 from . import normalise
-from .base import Operation
+from .base import Operation, resolve_collection
 
 coord_by_standard_name = {
     "realization": "realization",
@@ -48,7 +47,7 @@ class Concat(Operation):
             params.get("time_components")
         )
         dims = dimension_parameter.DimensionParameter(params.get("dims"))
-        collection = collection_parameter.CollectionParameter(collection)
+        collection = resolve_collection(collection)
 
         self.collection = collection
         self.params = {

--- a/src/rook/workflow.py
+++ b/src/rook/workflow.py
@@ -19,7 +19,7 @@ def is_file(data):
     try:
         ok = Path(data).is_file()
     except OSError as e:
-        LOGGER.warning(f"is_file check failed. reason={e}")
+        LOGGER.debug(f"is_file check failed. reason={e}")
         ok = False
     return ok
 

--- a/tests/test_operations_execution.py
+++ b/tests/test_operations_execution.py
@@ -6,6 +6,7 @@ import rook.operations.execution as execution_mod
 from rook.operations.average import Average, AverageShape, AverageTime
 from rook.operations import Operator
 from rook.operations.base import Operation, is_prepared_dataset_collection
+from rook.operations.concat import Concat
 from rook.operations.regrid import Regrid
 from rook.operations.subset import Subset
 
@@ -157,6 +158,7 @@ def test_operation_wrappers_accept_prepared_dataset_sources(monkeypatch):
         Average(collection=[prepared], dims=["time"]),
         AverageShape(collection=[prepared], shape="shape.geojson"),
         AverageTime(collection=[prepared], freq="year"),
+        Concat(collection=[prepared], dims="realization"),
         Regrid(collection=[prepared], grid="1deg"),
     ]
 

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -1,3 +1,5 @@
+import logging
+
 from rook import workflow
 
 
@@ -61,6 +63,16 @@ def test_run_step_dispatches_registered_workflow_operation(tmp_path):
         ["previous.nc"],
         ["result.nc"],
     )
+
+
+def test_load_wfdoc_inline_document_does_not_warn_about_file_check(caplog):
+    data = '{"doc": "' + ("x" * 300) + '", "steps": {}}'
+
+    caplog.set_level(logging.WARNING)
+    wfdoc = workflow.load_wfdoc(data)
+
+    assert wfdoc["doc"] == "x" * 300
+    assert "is_file check failed" not in caplog.text
 
 
 def test_run_wf_cmip6_subset_average(tmp_path, resource_file):


### PR DESCRIPTION
## Overview

This PR fixes the smoke tests for the `concat` operator.

## Related Issue / Discussion

## Additional Information


