### PR TITLE
Clean up concat and subset operator

### DIFF
--- a/src/rook/operations/concat.py
+++ b/src/rook/operations/concat.py
@@ -9,7 +9,6 @@ from clisops.parameter import dimension_parameter
 from clisops.parameter import time_components_parameter
 from clisops.parameter import time_parameter
 from clisops.project_utils import derive_ds_id
-from clisops.utils.dataset_utils import open_xr_dataset
 
 from rook.utils.decadal_fixes import apply_decadal_fixes, decadal_fix_calendar
 
@@ -27,25 +26,63 @@ def drop_time_bnds(ds: xr.Dataset) -> xr.Dataset:
     return ds
 
 
-def patched_normalise(collection):
-    norm_collection = collections.OrderedDict()
+def dataset_paths_by_id(sources):
+    """Return concat input paths keyed by dataset id."""
+    collection = collections.OrderedDict()
 
-    for dset, file_paths in collection.items():
-        fixed_datasets = [
-            decadal_fix_calendar(None, open_xr_dataset(file)) for file in file_paths
-        ]
-        ds = xr.concat(fixed_datasets, dim="time")
-        norm_collection[dset] = ds
+    for source in sources:
+        ds_id = source.dataset_id or derive_ds_id(source.paths[0])
+        collection[ds_id] = source.paths
 
-    return norm_collection
+    return collection
+
+
+def prepare_concat_input(ds):
+    """Apply concat-specific preparation before grouped files are combined."""
+    return decadal_fix_calendar(None, ds)
+
+
+def apply_concat_decadal_fixes(collection, output_dir):
+    """Apply concat-specific decadal fixes to each opened dataset."""
+    datasets = []
+
+    for ds_id, ds in collection.items():
+        datasets.append(apply_decadal_fixes(ds_id, ds, output_dir=output_dir))
+
+    return datasets
+
+
+def concat_dimension(dims):
+    """Return the dimension name and standard name used for concat."""
+    standard_name = dims[0]
+    return coord_by_standard_name.get(standard_name, None), standard_name
+
+
+def combine_concat_datasets(datasets, dim, standard_name):
+    """Concatenate datasets and restore concat coordinate metadata."""
+    ds = xr.concat(datasets, dim)
+    ds = ds.assign_coords({dim: (dim, np.array(ds[dim].values, dtype="int32"))})
+    ds.coords[dim].attrs = {"standard_name": standard_name}
+    return drop_time_bnds(ds)
+
+
+def finalise_concat_output(ds, params, dim):
+    """Apply optional average and time selection to concat output."""
+    if params.get("apply_average", False):
+        ds = average(ds, dims=[dim])
+
+    return subset(
+        ds,
+        time=params.get("time", None),
+        time_components=params.get("time_components", None),
+        output_type="nc",
+    )
 
 
 class Concat(Operation):
     def _resolve_params(self, collection, **params):
         time = time_parameter.TimeParameter(params.get("time"))
-        time_components = time_components_parameter.TimeComponentsParameter(
-            params.get("time_components")
-        )
+        time_components = time_components_parameter.TimeComponentsParameter(params.get("time_components"))
         dims = dimension_parameter.DimensionParameter(params.get("dims"))
         collection = resolve_collection(collection)
 
@@ -58,7 +95,7 @@ class Concat(Operation):
             "ignore_undetected_dims": params.get("ignore_undetected_dims"),
         }
 
-    def _calculate(self):
+    def calculate(self):
         config = {
             "output_type": self._output_type,
             "output_dir": self._output_dir,
@@ -68,47 +105,19 @@ class Concat(Operation):
 
         self.params.update(config)
 
-        new_collection = collections.OrderedDict()
-
-        for source in self.collection:
-            ds_id = source.dataset_id or derive_ds_id(source.paths[0])
-            new_collection[ds_id] = source.paths
-
-        norm_collection = patched_normalise(new_collection)
+        collection = dataset_paths_by_id(self.collection)
+        norm_collection = normalise.normalise_file_groups(
+            collection,
+            prepare_dataset=prepare_concat_input,
+        )
 
         rs = normalise.ResultSet(vars())
 
-        datasets = []
-        for ds_id in norm_collection.keys():
-            ds = norm_collection[ds_id]
-            ds_mod = apply_decadal_fixes(
-                ds_id, ds, output_dir=self.params.get("output_dir", ".")
-            )
-            datasets.append(ds_mod)
-
-        dims = dimension_parameter.DimensionParameter(
-            self.params.get("dims", None)
-        ).value
-        standard_name = dims[0]
-        dim = coord_by_standard_name.get(standard_name, None)
-
-        processed_ds = xr.concat(
-            datasets,
-            dim,
-        )
-        processed_ds = processed_ds.assign_coords(
-            {dim: (dim, np.array(processed_ds[dim].values, dtype="int32"))}
-        )
-        processed_ds.coords[dim].attrs = {"standard_name": standard_name}
-        processed_ds = drop_time_bnds(processed_ds)
-        if self.params.get("apply_average", False):
-            processed_ds = average(processed_ds, dims=[dim])
-        outputs = subset(
-            processed_ds,
-            time=self.params.get("time", None),
-            time_components=self.params.get("time_components", None),
-            output_type="nc",
-        )
+        datasets = apply_concat_decadal_fixes(norm_collection, output_dir=self.params.get("output_dir", "."))
+        dims = dimension_parameter.DimensionParameter(self.params.get("dims", None)).value
+        dim, standard_name = concat_dimension(dims)
+        processed_ds = combine_concat_datasets(datasets, dim, standard_name)
+        outputs = finalise_concat_output(processed_ds, self.params, dim)
         rs.add("output", outputs)
 
         return rs
@@ -137,4 +146,4 @@ def concat(
         split_method=split_method,
         file_namer=file_namer,
         apply_average=apply_average,
-    )._calculate()
+    ).calculate()

--- a/src/rook/operations/normalise.py
+++ b/src/rook/operations/normalise.py
@@ -3,7 +3,9 @@
 from collections import OrderedDict
 import pathlib
 
+from clisops.utils.dataset_utils import open_xr_dataset
 from loguru import logger
+import xarray as xr
 
 from rook.io.datasets import open_dataset
 
@@ -16,6 +18,31 @@ def normalise(collection):
     for source in collection:
         ds = open_dataset(source)
         norm_collection[source.key] = ds
+
+    return norm_collection
+
+
+def keep_dataset(ds):
+    """Return a dataset unchanged."""
+    return ds
+
+
+def normalise_file_groups(
+    collection,
+    *,
+    prepare_dataset=None,
+    concat_dim="time",
+    opener=open_xr_dataset,
+):
+    """Open grouped file paths and concatenate each group."""
+    norm_collection = OrderedDict()
+
+    if prepare_dataset is None:
+        prepare_dataset = keep_dataset
+
+    for dset, file_paths in collection.items():
+        datasets = [prepare_dataset(opener(file)) for file in file_paths]
+        norm_collection[dset] = xr.concat(datasets, dim=concat_dim)
 
     return norm_collection
 
@@ -33,7 +60,5 @@ class ResultSet:
         self._results[dset] = result
 
         for item in result:
-            if isinstance(item, str) and (
-                pathlib.Path(item).is_file() or item.startswith("https")
-            ):
+            if isinstance(item, str) and (pathlib.Path(item).is_file() or item.startswith("https")):
                 self.file_uris.append(item)

--- a/src/rook/operations/subset.py
+++ b/src/rook/operations/subset.py
@@ -9,7 +9,6 @@ from clisops.parameter import (
 )
 
 from .base import Operation, resolve_collection
-from . import normalise
 
 __all__ = ["Subset", "subset"]
 
@@ -21,28 +20,11 @@ class Subset(Operation):
             "area": area_parameter.AreaParameter(params.get("area")),
             "level": level_parameter.LevelParameter(params.get("level")),
             "time": time_parameter.TimeParameter(params.get("time")),
-            "time_components": time_components_parameter.TimeComponentsParameter(
-                params.get("time_components")
-            ),
+            "time_components": time_components_parameter.TimeComponentsParameter(params.get("time_components")),
         }
 
-    def calculate(self):
-        config = {
-            "output_type": self._output_type,
-            "output_dir": self._output_dir,
-            "split_method": self._split_method,
-            "file_namer": self._file_namer,
-        }
-
-        self.params.update(config)
-
-        norm_collection = normalise.normalise(self.collection)
-        rs = normalise.ResultSet(vars())
-
-        for dset, dataset in norm_collection.items():
-            rs.add(dset, clisops_subset(dataset, **self.params))
-
-        return rs
+    def get_operation_callable(self):
+        return clisops_subset
 
 
 def subset(

--- a/tests/test_operations_execution.py
+++ b/tests/test_operations_execution.py
@@ -158,3 +158,7 @@ def test_operation_wrappers_accept_prepared_dataset_sources(monkeypatch):
 
     for operation in operations:
         assert operation.collection == (prepared,)
+
+
+def test_subset_uses_base_operation_calculate():
+    assert Subset.calculate is Operation.calculate

--- a/tests/test_ops_concat.py
+++ b/tests/test_ops_concat.py
@@ -1,0 +1,86 @@
+import xarray as xr
+
+import rook.operations.concat as concat_mod
+from rook.io.datasets import DatasetSource
+
+
+def test_concat_dataset_paths_are_keyed_by_catalog_id(monkeypatch):
+    sources = [
+        DatasetSource("project.dataset", ["one.nc", "two.nc"]),
+        DatasetSource(None, ["direct.nc"]),
+    ]
+    monkeypatch.setattr(concat_mod, "derive_ds_id", lambda _path: "derived.dataset")
+
+    collection = concat_mod.dataset_paths_by_id(sources)
+
+    assert list(collection) == ["project.dataset", "derived.dataset"]
+    assert collection["project.dataset"] == ("one.nc", "two.nc")
+    assert collection["derived.dataset"] == ("direct.nc",)
+
+
+def test_prepare_concat_input_applies_decadal_calendar_fix(monkeypatch):
+    calls = []
+    source = xr.Dataset(attrs={"source": "input"})
+
+    def fake_calendar(ds_id, ds):
+        calls.append((ds_id, ds.attrs["source"]))
+        return ds
+
+    monkeypatch.setattr(concat_mod, "decadal_fix_calendar", fake_calendar)
+
+    result = concat_mod.prepare_concat_input(source)
+
+    assert result is source
+    assert calls == [(None, "input")]
+
+
+def test_apply_concat_decadal_fixes_preserves_dataset_identity(monkeypatch, tmp_path):
+    calls = []
+    first = xr.Dataset(attrs={"source": "first"})
+    second = xr.Dataset(attrs={"source": "second"})
+
+    def fake_apply(ds_id, ds, output_dir=None):
+        calls.append((ds_id, ds.attrs["source"], output_dir))
+        return ds.assign_attrs(fixed=ds_id)
+
+    monkeypatch.setattr(concat_mod, "apply_decadal_fixes", fake_apply)
+
+    datasets = concat_mod.apply_concat_decadal_fixes(
+        {"first.id": first, "second.id": second},
+        output_dir=tmp_path.as_posix(),
+    )
+
+    assert calls == [
+        ("first.id", "first", tmp_path.as_posix()),
+        ("second.id", "second", tmp_path.as_posix()),
+    ]
+    assert [ds.attrs["fixed"] for ds in datasets] == ["first.id", "second.id"]
+
+
+def test_combine_concat_datasets_sets_realization_coordinate_metadata():
+    datasets = [
+        xr.Dataset(
+            {
+                "tas": ("time", [1]),
+                "time_bnds": (("time", "bnds"), [[0, 1]]),
+            },
+            coords={"time": [0]},
+        ),
+        xr.Dataset(
+            {
+                "tas": ("time", [2]),
+                "time_bnds": (("time", "bnds"), [[0, 1]]),
+            },
+            coords={"time": [0]},
+        ),
+    ]
+
+    result = concat_mod.combine_concat_datasets(
+        datasets,
+        dim="realization",
+        standard_name="realization",
+    )
+
+    assert result.realization.dtype == "int32"
+    assert result.realization.attrs == {"standard_name": "realization"}
+    assert "time_bnds" not in result.variables

--- a/tests/test_ops_normalise.py
+++ b/tests/test_ops_normalise.py
@@ -1,0 +1,42 @@
+import xarray as xr
+
+from rook.operations import normalise
+
+
+def test_normalise_file_groups_opens_prepares_and_concatenates_files():
+    calls = []
+
+    def fake_open(path):
+        calls.append(("open", path))
+        return xr.Dataset({"tas": ("time", [1])}, coords={"time": [path]})
+
+    def prepare(ds):
+        calls.append(("prepare", ds.time.values[0]))
+        return ds
+
+    collection = normalise.normalise_file_groups(
+        {"dataset": ("one", "two")},
+        opener=fake_open,
+        prepare_dataset=prepare,
+    )
+
+    assert calls == [
+        ("open", "one"),
+        ("prepare", "one"),
+        ("open", "two"),
+        ("prepare", "two"),
+    ]
+    assert list(collection) == ["dataset"]
+    assert collection["dataset"].sizes["time"] == 2
+
+
+def test_normalise_file_groups_allows_plain_opening_without_prepare():
+    collection = normalise.normalise_file_groups(
+        {"dataset": ("one",)},
+        opener=lambda path: xr.Dataset(
+            {"tas": ("time", [1])},
+            coords={"time": [path]},
+        ),
+    )
+
+    assert collection["dataset"].time.values.tolist() == ["one"]


### PR DESCRIPTION
## Overview

This PR cleans up the `concat` and `subset` operator from legacy codes.

Changes:

- add `normalise_file_groups` for grouped file opening/preparation/concat
- keep concat-specific decadal preparation and fixes as explicit helper steps
- make concat use `calculate()` consistently
- remove the unnecessary `Subset.calculate()` override so subset uses the base operation flow
- add focused operator tests

## Related Issue / Discussion

## Additional Information


