### PR TITLE
update woodpecker integration

### DIFF
--- a/src/rook/fixes/__init__.py
+++ b/src/rook/fixes/__init__.py
@@ -6,7 +6,6 @@ from .providers import (
     FixProvider,
     LegacyDatasetFixProvider,
     WOODPECKER_ATLAS_RECIPE_ID,
-    WOODPECKER_CMIP6_DECADAL_CALENDAR_FIX_ID,
     WOODPECKER_CMIP6_DECADAL_RECIPE_ID,
     WoodpeckerDatasetFixProvider,
     get_dataset_fix_provider,
@@ -14,7 +13,6 @@ from .providers import (
 
 __all__ = [
     "WOODPECKER_ATLAS_RECIPE_ID",
-    "WOODPECKER_CMIP6_DECADAL_CALENDAR_FIX_ID",
     "WOODPECKER_CMIP6_DECADAL_RECIPE_ID",
     "DatasetFixProvider",
     "FixContext",

--- a/src/rook/fixes/providers/__init__.py
+++ b/src/rook/fixes/providers/__init__.py
@@ -8,9 +8,6 @@ from rook.fixes.providers.legacy import (
     LegacyDatasetFixProvider as LegacyDatasetFixProvider,
 )
 from rook.fixes.providers.woodpecker import (
-    WOODPECKER_CMIP6_DECADAL_CALENDAR_FIX_ID as WOODPECKER_CMIP6_DECADAL_CALENDAR_FIX_ID,
-)
-from rook.fixes.providers.woodpecker import (
     WOODPECKER_CMIP6_DECADAL_RECIPE_ID as WOODPECKER_CMIP6_DECADAL_RECIPE_ID,
 )
 from rook.fixes.providers.woodpecker import (

--- a/src/rook/fixes/providers/woodpecker.py
+++ b/src/rook/fixes/providers/woodpecker.py
@@ -34,7 +34,7 @@ class WoodpeckerDatasetFixProvider(FixProvider):
         # TODO: decide whether this special CMIP6-decadal pre-concat calendar
         # preparation remains an operation hook or should be represented by a
         # dedicated recipe/phase in Woodpecker.
-        self.woodpecker.fix(
+        self.woodpecker.apply(
             ds,
             fixes=WOODPECKER_CMIP6_DECADAL_CALENDAR_FIX_ID,
             dry_run=False,
@@ -55,7 +55,7 @@ class WoodpeckerDatasetFixProvider(FixProvider):
         woodpecker = self.woodpecker
         recipe_id = context.recipe_id or WOODPECKER_CMIP6_DECADAL_RECIPE_ID
         recipe = woodpecker.recipe.get(recipe_id)
-        woodpecker.recipe.fix(ds, recipe, dry_run=False)
+        woodpecker.recipe.apply(ds, recipe, dry_run=False)
         return ds
 
     def _apply_atlas_recipe(self, ds, dataset_id, recipe_id):
@@ -67,7 +67,7 @@ class WoodpeckerDatasetFixProvider(FixProvider):
 
         try:
             recipe = woodpecker.recipe.get(recipe_id)
-            woodpecker.recipe.fix(ds, recipe, dry_run=False)
+            woodpecker.recipe.apply(ds, recipe, dry_run=False)
         finally:
             if previous_dataset_id is None:
                 ds.attrs.pop("dataset_id", None)

--- a/src/rook/fixes/providers/woodpecker.py
+++ b/src/rook/fixes/providers/woodpecker.py
@@ -2,10 +2,11 @@
 
 import importlib
 
+from woodpecker.recipe import APPLY_PHASE, PREPARE_PHASE
+
 from rook.fixes.providers.base import FixContext, FixProvider
 
 WOODPECKER_CMIP6_DECADAL_RECIPE_ID = "c3s.cmip6_decadal"
-WOODPECKER_CMIP6_DECADAL_CALENDAR_FIX_ID = "cmip6_decadal.calendar_normalization"
 WOODPECKER_ATLAS_RECIPE_ID = "c3s.atlas"
 
 
@@ -31,15 +32,13 @@ class WoodpeckerDatasetFixProvider(FixProvider):
         return importlib.import_module("woodpecker")
 
     def prepare(self, ds, *, context=None):
-        # TODO: decide whether this special CMIP6-decadal pre-concat calendar
-        # preparation remains an operation hook or should be represented by a
-        # dedicated recipe/phase in Woodpecker.
-        self.woodpecker.apply(
+        context = context or FixContext()
+        recipe_id = context.recipe_id or WOODPECKER_CMIP6_DECADAL_RECIPE_ID
+        return self._apply_recipe(
             ds,
-            fixes=WOODPECKER_CMIP6_DECADAL_CALENDAR_FIX_ID,
-            dry_run=False,
+            recipe_id=recipe_id,
+            phase=context.phase or PREPARE_PHASE,
         )
-        return ds
 
     def apply(self, ds, *, context=None):
         context = context or FixContext()
@@ -54,9 +53,12 @@ class WoodpeckerDatasetFixProvider(FixProvider):
 
         woodpecker = self.woodpecker
         recipe_id = context.recipe_id or WOODPECKER_CMIP6_DECADAL_RECIPE_ID
-        recipe = woodpecker.recipe.get(recipe_id)
-        woodpecker.recipe.apply(ds, recipe, dry_run=False)
-        return ds
+        return self._apply_recipe(
+            ds,
+            recipe_id=recipe_id,
+            phase=context.phase or APPLY_PHASE,
+            woodpecker=woodpecker,
+        )
 
     def _apply_atlas_recipe(self, ds, dataset_id, recipe_id):
         woodpecker = self.woodpecker
@@ -66,8 +68,12 @@ class WoodpeckerDatasetFixProvider(FixProvider):
         ds.attrs["source_name"] = f"{dataset_id}.nc"
 
         try:
-            recipe = woodpecker.recipe.get(recipe_id)
-            woodpecker.recipe.apply(ds, recipe, dry_run=False)
+            self._apply_recipe(
+                ds,
+                recipe_id=recipe_id,
+                phase=APPLY_PHASE,
+                woodpecker=woodpecker,
+            )
         finally:
             if previous_dataset_id is None:
                 ds.attrs.pop("dataset_id", None)
@@ -79,4 +85,11 @@ class WoodpeckerDatasetFixProvider(FixProvider):
             else:
                 ds.attrs["source_name"] = previous_source_name
 
+        return ds
+
+    def _apply_recipe(self, ds, *, recipe_id, phase=None, woodpecker=None):
+        if woodpecker is None:
+            woodpecker = self.woodpecker
+        recipe = woodpecker.recipe.get(recipe_id)
+        woodpecker.recipe.apply(ds, recipe, phase=phase, dry_run=False)
         return ds

--- a/src/rook/fixes/providers/woodpecker.py
+++ b/src/rook/fixes/providers/woodpecker.py
@@ -4,9 +4,9 @@ import importlib
 
 from rook.fixes.providers.base import FixContext, FixProvider
 
-WOODPECKER_CMIP6_DECADAL_RECIPE_ID = "cmip6_decadal.full"
+WOODPECKER_CMIP6_DECADAL_RECIPE_ID = "c3s.cmip6_decadal"
 WOODPECKER_CMIP6_DECADAL_CALENDAR_FIX_ID = "cmip6_decadal.calendar_normalization"
-WOODPECKER_ATLAS_RECIPE_ID = "atlas.basic"
+WOODPECKER_ATLAS_RECIPE_ID = "c3s.atlas"
 
 
 class WoodpeckerDatasetFixProvider(FixProvider):

--- a/tests/test_atlas_fixes.py
+++ b/tests/test_atlas_fixes.py
@@ -51,7 +51,7 @@ def assert_same_dataset_and_encoding(left, right):
 
 
 def test_woodpecker_atlas_recipe_id_is_atlas_basic():
-    assert WOODPECKER_ATLAS_RECIPE_ID == "atlas.basic"
+    assert WOODPECKER_ATLAS_RECIPE_ID == "c3s.atlas"
 
 
 def test_woodpecker_atlas_fixes_match_legacy_rook_output():

--- a/tests/test_decadal_fixes.py
+++ b/tests/test_decadal_fixes.py
@@ -119,7 +119,7 @@ def assert_identical_with_report(left, right):
 
 
 def test_woodpecker_decadal_recipe_id_is_cmip6_decadal_full():
-    assert WOODPECKER_CMIP6_DECADAL_RECIPE_ID == "cmip6_decadal.full"
+    assert WOODPECKER_CMIP6_DECADAL_RECIPE_ID == "c3s.cmip6_decadal"
 
 
 def test_woodpecker_decadal_calendar_fix_id_is_calendar_normalization():

--- a/tests/test_decadal_fixes.py
+++ b/tests/test_decadal_fixes.py
@@ -4,7 +4,6 @@ import xarray as xr
 
 from rook.fixes.providers import (
     FixContext,
-    WOODPECKER_CMIP6_DECADAL_CALENDAR_FIX_ID,
     WOODPECKER_CMIP6_DECADAL_RECIPE_ID,
     WoodpeckerDatasetFixProvider,
 )
@@ -122,21 +121,15 @@ def test_woodpecker_decadal_recipe_id_is_cmip6_decadal_full():
     assert WOODPECKER_CMIP6_DECADAL_RECIPE_ID == "c3s.cmip6_decadal"
 
 
-def test_woodpecker_decadal_calendar_fix_id_is_calendar_normalization():
-    assert (
-        WOODPECKER_CMIP6_DECADAL_CALENDAR_FIX_ID
-        == "cmip6_decadal.calendar_normalization"
-    )
-
-
-def test_woodpecker_prepare_applies_decadal_calendar_fix():
+def test_woodpecker_prepare_applies_decadal_prepare_phase():
     dataset = make_proleptic_gregorian_decadal_sample()
 
     result = WoodpeckerDatasetFixProvider().prepare(
         dataset,
         context=FixContext(
             dataset_id=DECADAL_DS_ID,
-            recipe_id=WOODPECKER_CMIP6_DECADAL_CALENDAR_FIX_ID,
+            recipe_id=WOODPECKER_CMIP6_DECADAL_RECIPE_ID,
+            phase="prepare",
         ),
     )
 

--- a/tests/test_fixes_providers.py
+++ b/tests/test_fixes_providers.py
@@ -6,7 +6,6 @@ from rook.fixes.providers import (
     FixProvider,
     LegacyDatasetFixProvider,
     WOODPECKER_ATLAS_RECIPE_ID,
-    WOODPECKER_CMIP6_DECADAL_CALENDAR_FIX_ID,
     WOODPECKER_CMIP6_DECADAL_RECIPE_ID,
     WoodpeckerDatasetFixProvider,
     get_dataset_fix_provider,
@@ -138,10 +137,18 @@ def test_woodpecker_provider_prepares_decadal_concat_dataset(monkeypatch):
     calls = []
     source = xr.Dataset(attrs={"source": "input"})
 
-    class FakeWoodpecker:
+    class FakeRecipe:
         @staticmethod
-        def apply(ds, *, fixes=None, dry_run=True):
-            calls.append(("apply", ds.attrs["source"], fixes, dry_run))
+        def get(recipe_id):
+            calls.append(("get", recipe_id))
+            return {"id": recipe_id}
+
+        @staticmethod
+        def apply(ds, recipe, phase=None, dry_run=True):
+            calls.append(("apply", recipe["id"], ds.attrs["source"], phase, dry_run))
+
+    class FakeWoodpecker:
+        recipe = FakeRecipe
 
     monkeypatch.setattr(
         WoodpeckerDatasetFixProvider, "require_available", lambda self: None
@@ -155,7 +162,8 @@ def test_woodpecker_provider_prepares_decadal_concat_dataset(monkeypatch):
 
     assert result is source
     assert calls == [
-        ("apply", "input", WOODPECKER_CMIP6_DECADAL_CALENDAR_FIX_ID, False),
+        ("get", WOODPECKER_CMIP6_DECADAL_RECIPE_ID),
+        ("apply", WOODPECKER_CMIP6_DECADAL_RECIPE_ID, "input", "prepare", False),
     ]
 
 
@@ -174,8 +182,8 @@ def test_woodpecker_provider_applies_decadal_recipe_without_check(monkeypatch):
             raise AssertionError("Rook should call Woodpecker apply directly")
 
         @staticmethod
-        def apply(ds, recipe, dry_run=True):
-            calls.append(("apply", recipe["id"], ds.attrs["source"], dry_run))
+        def apply(ds, recipe, phase=None, dry_run=True):
+            calls.append(("apply", recipe["id"], ds.attrs["source"], phase, dry_run))
 
     class FakeWoodpecker:
         recipe = FakeRecipe
@@ -193,7 +201,7 @@ def test_woodpecker_provider_applies_decadal_recipe_without_check(monkeypatch):
     assert result is source
     assert calls == [
         ("get", WOODPECKER_CMIP6_DECADAL_RECIPE_ID),
-        ("apply", WOODPECKER_CMIP6_DECADAL_RECIPE_ID, "input", False),
+        ("apply", WOODPECKER_CMIP6_DECADAL_RECIPE_ID, "input", "apply", False),
     ]
 
 
@@ -208,13 +216,14 @@ def test_woodpecker_provider_applies_atlas_recipe(monkeypatch):
             return {"id": recipe_id}
 
         @staticmethod
-        def apply(ds, recipe, dry_run=True):
+        def apply(ds, recipe, phase=None, dry_run=True):
             calls.append(
                 (
                     "apply",
                     recipe["id"],
                     ds.attrs["dataset_id"],
                     ds.attrs["source_name"],
+                    phase,
                     dry_run,
                 )
             )
@@ -242,6 +251,7 @@ def test_woodpecker_provider_applies_atlas_recipe(monkeypatch):
             WOODPECKER_ATLAS_RECIPE_ID,
             "c3s-ipcc-atlas.tnn.CMIP6.historical.mon",
             "c3s-ipcc-atlas.tnn.CMIP6.historical.mon.nc",
+            "apply",
             False,
         ),
     ]

--- a/tests/test_fixes_providers.py
+++ b/tests/test_fixes_providers.py
@@ -140,8 +140,8 @@ def test_woodpecker_provider_prepares_decadal_concat_dataset(monkeypatch):
 
     class FakeWoodpecker:
         @staticmethod
-        def fix(ds, *, fixes=None, dry_run=True):
-            calls.append(("fix", ds.attrs["source"], fixes, dry_run))
+        def apply(ds, *, fixes=None, dry_run=True):
+            calls.append(("apply", ds.attrs["source"], fixes, dry_run))
 
     monkeypatch.setattr(
         WoodpeckerDatasetFixProvider, "require_available", lambda self: None
@@ -155,7 +155,7 @@ def test_woodpecker_provider_prepares_decadal_concat_dataset(monkeypatch):
 
     assert result is source
     assert calls == [
-        ("fix", "input", WOODPECKER_CMIP6_DECADAL_CALENDAR_FIX_ID, False),
+        ("apply", "input", WOODPECKER_CMIP6_DECADAL_CALENDAR_FIX_ID, False),
     ]
 
 
@@ -171,11 +171,11 @@ def test_woodpecker_provider_applies_decadal_recipe_without_check(monkeypatch):
 
         @staticmethod
         def check(ds, recipe):
-            raise AssertionError("Rook should call Woodpecker fix directly")
+            raise AssertionError("Rook should call Woodpecker apply directly")
 
         @staticmethod
-        def fix(ds, recipe, dry_run=True):
-            calls.append(("fix", recipe["id"], ds.attrs["source"], dry_run))
+        def apply(ds, recipe, dry_run=True):
+            calls.append(("apply", recipe["id"], ds.attrs["source"], dry_run))
 
     class FakeWoodpecker:
         recipe = FakeRecipe
@@ -193,7 +193,7 @@ def test_woodpecker_provider_applies_decadal_recipe_without_check(monkeypatch):
     assert result is source
     assert calls == [
         ("get", WOODPECKER_CMIP6_DECADAL_RECIPE_ID),
-        ("fix", WOODPECKER_CMIP6_DECADAL_RECIPE_ID, "input", False),
+        ("apply", WOODPECKER_CMIP6_DECADAL_RECIPE_ID, "input", False),
     ]
 
 
@@ -208,10 +208,10 @@ def test_woodpecker_provider_applies_atlas_recipe(monkeypatch):
             return {"id": recipe_id}
 
         @staticmethod
-        def fix(ds, recipe, dry_run=True):
+        def apply(ds, recipe, dry_run=True):
             calls.append(
                 (
-                    "fix",
+                    "apply",
                     recipe["id"],
                     ds.attrs["dataset_id"],
                     ds.attrs["source_name"],
@@ -238,7 +238,7 @@ def test_woodpecker_provider_applies_atlas_recipe(monkeypatch):
     assert calls == [
         ("get", WOODPECKER_ATLAS_RECIPE_ID),
         (
-            "fix",
+            "apply",
             WOODPECKER_ATLAS_RECIPE_ID,
             "c3s-ipcc-atlas.tnn.CMIP6.historical.mon",
             "c3s-ipcc-atlas.tnn.CMIP6.historical.mon.nc",


### PR DESCRIPTION
## Overview

This PR updates to the woodpecker changes.

Changes:

* use phases `prepare`, `apply` and `finalize` to apply fixes
* use `apply` instead of `fix` command
* use recipes with `c3s` prefix

## Related Issue / Discussion

## Additional Information


