### PR TITLE
Use Woodpecker synthetic data for focused fix tests

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -161,6 +161,30 @@ should stay visible:
 - add a new process for health checks;
 - clean up all WPS process modules in general.
 
+## Synthetic Test Data
+
+Woodpecker already provides synthetic test data builders such as
+`woodpecker.testing.make_cmip6_decadal`, `make_atlas`, `make_cmip6`, `make_cmip7`,
+and `make_cordex`. Use these for focused fix/provider tests while keeping
+mini-esgf-data for integration coverage that needs realistic catalog paths,
+public URL behavior, WPS catalog configuration, or path-resolution behavior.
+
+Work in small steps:
+
+1. Make mini-esgf-data opt-in for tests that actually need it. The current
+   session-autouse `load_test_data` fixture means synthetic-only tests still
+   touch the mini-ESGF cache, which makes focused provider tests heavier and
+   harder to run in restricted environments.
+2. Keep mini-esgf-data coverage for WPS, catalog lookup, path resolution,
+   metalink/public URL behavior, and other integration checks that need the
+   realistic file layout.
+3. Add or migrate focused fix tests to synthetic Woodpecker data, especially
+   decadal calendar preparation, decadal apply behavior, atlas fixes, and
+   provider routing.
+4. Add synthetic concat coverage using temporary NetCDF files so the
+   per-file `prepare` step, grouped time concat, and dataset-id-aware `apply`
+   step are tested without depending on mini-esgf-data.
+
 ## Deferred Features
 
 These remain outside this cleanup phase:

--- a/TODO.md
+++ b/TODO.md
@@ -171,17 +171,17 @@ public URL behavior, WPS catalog configuration, or path-resolution behavior.
 
 Work in small steps:
 
-1. Make mini-esgf-data opt-in for tests that actually need it. The current
-   session-autouse `load_test_data` fixture means synthetic-only tests still
-   touch the mini-ESGF cache, which makes focused provider tests heavier and
-   harder to run in restricted environments.
-2. Keep mini-esgf-data coverage for WPS, catalog lookup, path resolution,
+1. [x] Make mini-esgf-data opt-in for tests that actually need it.
+   `load_test_data` and the mini-ESGF roocs config fixture are no longer
+   session-autouse; tests that need them use the `mini_esgf_data` marker and
+   `load_test_data` fixture explicitly.
+2. [x] Keep mini-esgf-data coverage for WPS, catalog lookup, path resolution,
    metalink/public URL behavior, and other integration checks that need the
-   realistic file layout.
-3. Add or migrate focused fix tests to synthetic Woodpecker data, especially
+   realistic file layout. These tests are marked with `mini_esgf_data`.
+3. [ ] Add or migrate focused fix tests to synthetic Woodpecker data, especially
    decadal calendar preparation, decadal apply behavior, atlas fixes, and
    provider routing.
-4. Add synthetic concat coverage using temporary NetCDF files so the
+4. [ ] Add synthetic concat coverage using temporary NetCDF files so the
    per-file `prepare` step, grouped time concat, and dataset-id-aware `apply`
    step are tested without depending on mini-esgf-data.
 

--- a/TODO.md
+++ b/TODO.md
@@ -178,10 +178,10 @@ Work in small steps:
 2. [x] Keep mini-esgf-data coverage for WPS, catalog lookup, path resolution,
    metalink/public URL behavior, and other integration checks that need the
    realistic file layout. These tests are marked with `mini_esgf_data`.
-3. [ ] Add or migrate focused fix tests to synthetic Woodpecker data, especially
+3. [x] Add or migrate focused fix tests to synthetic Woodpecker data, especially
    decadal calendar preparation, decadal apply behavior, atlas fixes, and
    provider routing.
-4. [ ] Add synthetic concat coverage using temporary NetCDF files so the
+4. [x] Add synthetic concat coverage using temporary NetCDF files so the
    per-file `prepare` step, grouped time concat, and dataset-id-aware `apply`
    step are tested without depending on mini-esgf-data.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -253,6 +253,7 @@ addopts = [
 ]
 python_files = ["test_*.py"]
 markers = [
+  "mini_esgf_data: mark test to require the mini-ESGF test data cache",
   "online: mark test to need internet connection",
   "smoke: mark test as a smoke/sanity test"
 ]

--- a/src/rook/operations/concat.py
+++ b/src/rook/operations/concat.py
@@ -95,7 +95,10 @@ def finalise_concat_output(ds, params, dim):
         ds,
         time=params.get("time", None),
         time_components=params.get("time_components", None),
-        output_type="nc",
+        output_dir=params.get("output_dir"),
+        output_type=params.get("output_type", "netcdf"),
+        split_method=params.get("split_method", "time:auto"),
+        file_namer=params.get("file_namer", "standard"),
     )
 
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,4 +1,4 @@
-"""Synthetic datasets and sources for focused tests."""
+"""Common helpers for tests."""
 
 import pytest
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -183,7 +183,7 @@ def get_output():
     return _get_output
 
 
-@pytest.fixture(scope="session", autouse=True)
+@pytest.fixture(scope="session")
 def load_test_data(stratus, write_roocs_cfg):
     """Ensure that the required test data repository has been cloned to the cache directory within the home directory."""
     cache_dir = Path(ESGF_TEST_DATA_CACHE_DIR)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,7 @@ from pywps import get_ElementMakerForVersion
 from pywps.app.basic import get_xpath_ns
 from pywps.tests import WpsClient, WpsTestResponse
 
-from synthetic import make_synthetic_cmip6_decadal_source
+from common import make_synthetic_cmip6_decadal_source
 
 VERSION = "1.0.0"
 WPS, OWS = get_ElementMakerForVersion(VERSION)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,7 +71,7 @@ def stratus():
     )
 
 
-@pytest.fixture(scope="session", autouse=True)
+@pytest.fixture(scope="session")
 def write_roocs_cfg(stratus):
     cfg_templ = """
     [clisops:write]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,7 @@ from pywps import get_ElementMakerForVersion
 from pywps.app.basic import get_xpath_ns
 from pywps.tests import WpsClient, WpsTestResponse
 
-from rook.io.datasets import DatasetSource
+from synthetic import make_synthetic_cmip6_decadal_source
 
 VERSION = "1.0.0"
 WPS, OWS = get_ElementMakerForVersion(VERSION)
@@ -28,10 +28,6 @@ xpath_ns = get_xpath_ns(VERSION)
 TESTS_HOME = Path(__file__).parent.absolute()
 ROOCS_CFG = TESTS_HOME.joinpath(".roocs.ini")
 PYWPS_CFG = TESTS_HOME.joinpath("pywps.cfg")
-SYNTHETIC_CMIP6_DECADAL_DATASET_ID = (
-    "c3s-cmip6-decadal.DCPP.MPI-M.MPI-ESM1-2-HR.dcppA-hindcast."
-    "s1960-r1i1p1f1.Omon.tos.gn.v20200101"
-)
 
 TEST_DATA_FILE_PATTERNS = (
     "badc/cmip5/data/cmip5/output1/ICHEC/EC-EARTH/historical/mon/atmos/Amon/r1i1p1/latest/tas/",
@@ -70,17 +66,7 @@ def missing_test_data_files(base_dir):
 
 @pytest.fixture()
 def synthetic_cmip6_decadal_source(tmp_path):
-    woodpecker_testing = pytest.importorskip("woodpecker.testing")
-    pytest.importorskip("woodpecker_cmip6_decadal_plugin")
-    dataset = woodpecker_testing.make_cmip6_decadal(seed=1).isel(time=slice(0, 2))
-    paths = []
-
-    for index in range(2):
-        path = tmp_path / f"synthetic-decadal-{index}.nc"
-        dataset.isel(time=[index]).to_netcdf(path)
-        paths.append(path.as_posix())
-
-    return DatasetSource(SYNTHETIC_CMIP6_DECADAL_DATASET_ID, paths)
+    return make_synthetic_cmip6_decadal_source(tmp_path)
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,8 @@ from pywps import get_ElementMakerForVersion
 from pywps.app.basic import get_xpath_ns
 from pywps.tests import WpsClient, WpsTestResponse
 
+from rook.io.datasets import DatasetSource
+
 VERSION = "1.0.0"
 WPS, OWS = get_ElementMakerForVersion(VERSION)
 xpath_ns = get_xpath_ns(VERSION)
@@ -26,6 +28,10 @@ xpath_ns = get_xpath_ns(VERSION)
 TESTS_HOME = Path(__file__).parent.absolute()
 ROOCS_CFG = TESTS_HOME.joinpath(".roocs.ini")
 PYWPS_CFG = TESTS_HOME.joinpath("pywps.cfg")
+SYNTHETIC_CMIP6_DECADAL_DATASET_ID = (
+    "c3s-cmip6-decadal.DCPP.MPI-M.MPI-ESM1-2-HR.dcppA-hindcast."
+    "s1960-r1i1p1f1.Omon.tos.gn.v20200101"
+)
 
 TEST_DATA_FILE_PATTERNS = (
     "badc/cmip5/data/cmip5/output1/ICHEC/EC-EARTH/historical/mon/atmos/Amon/r1i1p1/latest/tas/",
@@ -60,6 +66,21 @@ def missing_test_data_files(base_dir):
         for filename in required_test_data_files()
         if not base_dir.joinpath(filename).exists()
     ]
+
+
+@pytest.fixture()
+def synthetic_cmip6_decadal_source(tmp_path):
+    woodpecker_testing = pytest.importorskip("woodpecker.testing")
+    pytest.importorskip("woodpecker_cmip6_decadal_plugin")
+    dataset = woodpecker_testing.make_cmip6_decadal(seed=1).isel(time=slice(0, 2))
+    paths = []
+
+    for index in range(2):
+        path = tmp_path / f"synthetic-decadal-{index}.nc"
+        dataset.isel(time=[index]).to_netcdf(path)
+        paths.append(path.as_posix())
+
+    return DatasetSource(SYNTHETIC_CMIP6_DECADAL_DATASET_ID, paths)
 
 
 @pytest.fixture(scope="session")

--- a/tests/synthetic.py
+++ b/tests/synthetic.py
@@ -1,0 +1,24 @@
+"""Synthetic datasets and sources for focused tests."""
+
+import pytest
+
+from rook.io.datasets import DatasetSource
+
+SYNTHETIC_CMIP6_DECADAL_DATASET_ID = (
+    "c3s-cmip6-decadal.DCPP.MPI-M.MPI-ESM1-2-HR.dcppA-hindcast."
+    "s1960-r1i1p1f1.Omon.tos.gn.v20200101"
+)
+
+
+def make_synthetic_cmip6_decadal_source(tmp_path):
+    woodpecker_testing = pytest.importorskip("woodpecker.testing")
+    pytest.importorskip("woodpecker_cmip6_decadal_plugin")
+    dataset = woodpecker_testing.make_cmip6_decadal(seed=1).isel(time=slice(0, 2))
+    paths = []
+
+    for index in range(2):
+        path = tmp_path / f"synthetic-decadal-{index}.nc"
+        dataset.isel(time=[index]).to_netcdf(path)
+        paths.append(path.as_posix())
+
+    return DatasetSource(SYNTHETIC_CMIP6_DECADAL_DATASET_ID, paths)

--- a/tests/test_atlas_fixes.py
+++ b/tests/test_atlas_fixes.py
@@ -8,17 +8,21 @@ from rook.fixes.providers import (
     WoodpeckerDatasetFixProvider,
 )
 
-pytest.importorskip("woodpecker")
+woodpecker_testing = pytest.importorskip("woodpecker.testing")
 pytest.importorskip("woodpecker_atlas_plugin")
 
 ATLAS_DS_ID = "c3s-ipcc-atlas.tnn.CMIP6.historical.mon"
 
 
 def make_representative_atlas_sample():
-    dataset = xr.Dataset(
-        {"tas": ("time", [280.0, 281.0])},
-        coords={"time": [0, 1], "member_id": ("member_id", ["r1i1p1f1"])},
+    dataset = woodpecker_testing.make_atlas(variable="tas", seed=1).isel(
+        time=slice(0, 2),
+        lat=slice(0, 2),
+        lon=slice(0, 2),
     )
+    dataset.attrs.pop("project_id", None)
+    dataset = dataset.assign_coords(member_id=("member_id", ["r1i1p1f1"]))
+
     for var in list(dataset.coords) + list(dataset.data_vars):
         dataset[var].encoding["_FillValue"] = "missing"
     dataset["member_id"].encoding.update(

--- a/tests/test_catalog_intake.py
+++ b/tests/test_catalog_intake.py
@@ -1,6 +1,9 @@
+import pytest
 import types
 
 from rook.catalog.intake import IntakeCatalog
+
+pytestmark = [pytest.mark.mini_esgf_data, pytest.mark.usefixtures("load_test_data")]
 
 C3S_CMIP6_DAY_COLLECTION = (
     "c3s-cmip6.CMIP.SNU.SAM0-UNICON.historical.r1i1p1f1.day.pr.gn.v20190323"

--- a/tests/test_catalog_intake.py
+++ b/tests/test_catalog_intake.py
@@ -3,8 +3,6 @@ import types
 
 from rook.catalog.intake import IntakeCatalog
 
-pytestmark = [pytest.mark.mini_esgf_data, pytest.mark.usefixtures("load_test_data")]
-
 C3S_CMIP6_DAY_COLLECTION = (
     "c3s-cmip6.CMIP.SNU.SAM0-UNICON.historical.r1i1p1f1.day.pr.gn.v20190323"
 )
@@ -16,6 +14,8 @@ C3S_CMIP6_FX_COLLECTION = (
 )
 
 
+@pytest.mark.mini_esgf_data
+@pytest.mark.usefixtures("load_test_data")
 def test_intake_catalog_c3s_cmip6_mon(stratus):
     cat = IntakeCatalog(project="c3s-cmip6")
     result = cat.search(collection=C3S_CMIP6_MON_COLLECTION)
@@ -37,6 +37,8 @@ def test_intake_catalog_c3s_cmip6_mon(stratus):
     assert expected_url == urls[0]
 
 
+@pytest.mark.mini_esgf_data
+@pytest.mark.usefixtures("load_test_data")
 def test_intake_catalog_c3s_cmip6_day():
     cat = IntakeCatalog(project="c3s-cmip6")
     # all files
@@ -56,6 +58,8 @@ def test_intake_catalog_c3s_cmip6_day():
     assert "pr_day_SAM0-UNICON_historical_r1i1p1f1_gn_19000101-19001231.nc" in files[0]
 
 
+@pytest.mark.mini_esgf_data
+@pytest.mark.usefixtures("load_test_data")
 def test_intake_catalog_c3s_cmip6_fx():
     cat = IntakeCatalog(project="c3s-cmip6")
     result = cat.search(collection=C3S_CMIP6_FX_COLLECTION)
@@ -75,6 +79,8 @@ def test_intake_catalog_c3s_cmip6_fx():
     assert len(files) == 1
 
 
+@pytest.mark.mini_esgf_data
+@pytest.mark.usefixtures("load_test_data")
 def test_intake_catalog_c3s_cmip6_multiple():
     cat = IntakeCatalog(project="c3s-cmip6")
     result = cat.search(collection=[C3S_CMIP6_MON_COLLECTION, C3S_CMIP6_FX_COLLECTION])

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,4 +1,8 @@
+import pytest
+
 from rook.catalog import DBCatalog
+
+pytestmark = [pytest.mark.mini_esgf_data, pytest.mark.usefixtures("load_test_data")]
 
 C3S_CMIP6_DAY_COLLECTION = (
     "c3s-cmip6.CMIP.SNU.SAM0-UNICON.historical.r1i1p1f1.day.pr.gn.v20190323"

--- a/tests/test_ops_concat.py
+++ b/tests/test_ops_concat.py
@@ -1,3 +1,4 @@
+import numpy as np
 import xarray as xr
 
 import rook.operations.concat as concat_mod
@@ -230,6 +231,32 @@ def test_concat_uses_synthetic_decadal_files_with_woodpecker_provider(
         assert dataset.realization.attrs == {"standard_name": "realization"}
         assert dataset.attrs["project_id"] == "CMIP6"
         assert dataset.attrs["dataset_id"].startswith("CMIP6.DCPP.")
+
+
+def test_finalise_concat_output_writes_to_configured_output_dir(tmp_path):
+    dataset = xr.Dataset(
+        {"tas": (("realization", "time"), [[280.0, 281.0]])},
+        coords={
+            "realization": [0],
+            "time": np.array(["2000-01-01", "2000-02-01"], dtype="datetime64[ns]"),
+        },
+    )
+    dataset.realization.attrs = {"standard_name": "realization"}
+
+    outputs = concat_mod.finalise_concat_output(
+        dataset,
+        {
+            "output_dir": tmp_path.as_posix(),
+            "output_type": "netcdf",
+            "split_method": "time:auto",
+            "file_namer": "standard",
+        },
+        dim="realization",
+    )
+
+    assert len(outputs) == 1
+    assert outputs[0].startswith(tmp_path.as_posix())
+    assert (tmp_path / "output_001.nc").is_file()
 
 
 def test_combine_concat_datasets_sets_realization_coordinate_metadata():

--- a/tests/test_ops_concat.py
+++ b/tests/test_ops_concat.py
@@ -211,6 +211,27 @@ def test_concat_can_override_configured_fix_provider(monkeypatch, tmp_path):
     assert calls == [("provider", "woodpecker")]
 
 
+def test_concat_uses_synthetic_decadal_files_with_woodpecker_provider(
+    tmp_path, synthetic_cmip6_decadal_source
+):
+    result = concat_mod.concat(
+        collection=[synthetic_cmip6_decadal_source],
+        dims=["realization"],
+        output_dir=tmp_path.as_posix(),
+        fix_provider="woodpecker",
+    )
+
+    assert len(result.file_uris) == 1
+    assert result.file_uris[0].startswith(tmp_path.as_posix())
+
+    with xr.open_dataset(result.file_uris[0]) as dataset:
+        assert dataset.sizes["time"] == 2
+        assert dataset.sizes["realization"] == 1
+        assert dataset.realization.attrs == {"standard_name": "realization"}
+        assert dataset.attrs["project_id"] == "CMIP6"
+        assert dataset.attrs["dataset_id"].startswith("CMIP6.DCPP.")
+
+
 def test_combine_concat_datasets_sets_realization_coordinate_metadata():
     datasets = [
         xr.Dataset(

--- a/tests/test_pflow/test_alignment.py
+++ b/tests/test_pflow/test_alignment.py
@@ -2,6 +2,8 @@ import pytest
 
 from rook.pflow.alignment import SubsetAlignmentChecker
 
+pytestmark = [pytest.mark.mini_esgf_data, pytest.mark.usefixtures("load_test_data")]
+
 
 class TestYearMonth:
     """Tests with year and month only, not day."""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,6 +8,8 @@ from rook.utils.input_utils import (
 )
 from rook.utils.metalink_utils import build_metalink
 
+pytestmark = [pytest.mark.mini_esgf_data, pytest.mark.usefixtures("load_test_data")]
+
 
 def test_build_metalink(tmpdir, stratus):
     cmip6_nc = stratus.path.joinpath(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,9 +8,9 @@ from rook.utils.input_utils import (
 )
 from rook.utils.metalink_utils import build_metalink
 
-pytestmark = [pytest.mark.mini_esgf_data, pytest.mark.usefixtures("load_test_data")]
 
-
+@pytest.mark.mini_esgf_data
+@pytest.mark.usefixtures("load_test_data")
 def test_build_metalink(tmpdir, stratus):
     cmip6_nc = stratus.path.joinpath(
         "badc/cmip6/data/CMIP6/CMIP/MPI-M/MPI-ESM1-2-HR/historical/r1i1p1f1/SImon/siconc"
@@ -63,6 +63,8 @@ def test_resolve_to_file_paths_mixed():
         )
 
 
+@pytest.mark.mini_esgf_data
+@pytest.mark.usefixtures("load_test_data")
 def test_resolve_to_file_paths_urls(stratus):
     coll = [
         "https://data.mips.climate.copernicus.eu/thredds/fileServer/esg_c3s-cmip6/CMIP/E3SM-Project/E3SM-1-1"

--- a/tests/test_wps_average_dim.py
+++ b/tests/test_wps_average_dim.py
@@ -1,7 +1,10 @@
+import pytest
 from pywps import Service
 from pywps.tests import assert_process_exception, assert_response_success, client_for
 
 from rook.processes.wps_average_dim import AverageByDimension
+
+pytestmark = [pytest.mark.mini_esgf_data, pytest.mark.usefixtures("load_test_data")]
 
 
 def test_wps_average_time_cmip5(get_output, pywps_cfg):

--- a/tests/test_wps_average_shape.py
+++ b/tests/test_wps_average_shape.py
@@ -10,6 +10,8 @@ import pytest
 
 from rook.processes.wps_average_shape import AverageByShape
 
+pytestmark = [pytest.mark.mini_esgf_data, pytest.mark.usefixtures("load_test_data")]
+
 
 ESMPY_MISSING = importlib.util.find_spec("esmpy") is None
 

--- a/tests/test_wps_average_time.py
+++ b/tests/test_wps_average_time.py
@@ -1,7 +1,10 @@
+import pytest
 from pywps import Service
 from pywps.tests import assert_process_exception, assert_response_success, client_for
 
 from rook.processes.wps_average_time import AverageByTime
+
+pytestmark = [pytest.mark.mini_esgf_data, pytest.mark.usefixtures("load_test_data")]
 
 
 def test_wps_average_year_cmip5(get_output, pywps_cfg):

--- a/tests/test_wps_average_weighted.py
+++ b/tests/test_wps_average_weighted.py
@@ -1,9 +1,12 @@
+import pytest
 import xarray as xr
 from pywps import Service
 from pywps.tests import assert_response_success, client_for
 
 from rook.processes.wps_average_weighted import WeightedAverage
 from rook.utils.metalink_utils import extract_paths_from_metalink
+
+pytestmark = [pytest.mark.mini_esgf_data, pytest.mark.usefixtures("load_test_data")]
 
 
 def assert_weighted_average(path):

--- a/tests/test_wps_cmip6_decadal.py
+++ b/tests/test_wps_cmip6_decadal.py
@@ -6,6 +6,8 @@ from pywps.tests import assert_response_success, client_for
 from rook.processes.wps_subset import Subset
 from rook.utils.metalink_utils import extract_paths_from_metalink
 
+pytestmark = [pytest.mark.mini_esgf_data, pytest.mark.usefixtures("load_test_data")]
+
 
 def assert_decadal_fix_applied(path):
     assert "meta4" in path

--- a/tests/test_wps_concat.py
+++ b/tests/test_wps_concat.py
@@ -4,6 +4,8 @@ from pywps.tests import assert_response_success, client_for
 
 from rook.processes.wps_concat import Concat
 
+pytestmark = [pytest.mark.mini_esgf_data, pytest.mark.usefixtures("load_test_data")]
+
 
 def test_wps_concat_exposes_fix_provider_override_not_fix_backend():
     process = Concat()

--- a/tests/test_wps_concat.py
+++ b/tests/test_wps_concat.py
@@ -4,8 +4,6 @@ from pywps.tests import assert_response_success, client_for
 
 from rook.processes.wps_concat import Concat
 
-pytestmark = [pytest.mark.mini_esgf_data, pytest.mark.usefixtures("load_test_data")]
-
 
 def test_wps_concat_exposes_fix_provider_override_not_fix_backend():
     process = Concat()
@@ -15,6 +13,8 @@ def test_wps_concat_exposes_fix_provider_override_not_fix_backend():
     assert "fix_backend" not in inputs
 
 
+@pytest.mark.mini_esgf_data
+@pytest.mark.usefixtures("load_test_data")
 @pytest.mark.xfail(reason="c3s-cmip6 decdal not in catalog")
 def test_wps_concat_ec_earth(get_output, pywps_cfg):
     client = client_for(Service(processes=[Concat()], cfgfiles=[pywps_cfg]))

--- a/tests/test_wps_orchestrate.py
+++ b/tests/test_wps_orchestrate.py
@@ -10,6 +10,8 @@ from pywps.tests import assert_response_success, client_for
 from rook.processes.wps_orchestrate import Orchestrate
 from rook.utils.metalink_utils import parse_metalink
 
+pytestmark = [pytest.mark.mini_esgf_data, pytest.mark.usefixtures("load_test_data")]
+
 
 ESMPY_MISSING = importlib.util.find_spec("esmpy") is None
 

--- a/tests/test_wps_regrid.py
+++ b/tests/test_wps_regrid.py
@@ -8,6 +8,8 @@ from pywps.tests import assert_response_success, client_for
 from rook.processes.wps_regrid import Regrid
 from rook.utils.metalink_utils import extract_paths_from_metalink
 
+pytestmark = [pytest.mark.mini_esgf_data, pytest.mark.usefixtures("load_test_data")]
+
 
 ESMPY_MISSING = importlib.util.find_spec("esmpy") is None
 

--- a/tests/test_wps_subset.py
+++ b/tests/test_wps_subset.py
@@ -9,8 +9,6 @@ from pywps.tests import assert_process_exception, assert_response_success, clien
 from rook.processes.wps_subset import Subset
 from rook.utils.metalink_utils import parse_metalink
 
-pytestmark = [pytest.mark.mini_esgf_data, pytest.mark.usefixtures("load_test_data")]
-
 C3S_CMIP6_MON_COLLECTION = (
     "c3s-cmip6.ScenarioMIP.INM.INM-CM5-0.ssp245.r1i1p1f1.Amon.rlds.gr1.v20190619"
 )
@@ -34,6 +32,8 @@ def test_wps_subset_exposes_fix_provider_override():
     assert "fix_backend" not in inputs
 
 
+@pytest.mark.mini_esgf_data
+@pytest.mark.usefixtures("load_test_data")
 def test_wps_subset_cmip6_no_inv(pywps_cfg):
     client = client_for(Service(processes=[Subset()], cfgfiles=[pywps_cfg]))
     datainputs = "collection=c3s-cmip6.CMIP.MPI-M.MPI-ESM1-2-HR.historical.r1i1p1f1.SImon.siconc.gn.latest"
@@ -47,6 +47,8 @@ def test_wps_subset_cmip6_no_inv(pywps_cfg):
     )
 
 
+@pytest.mark.mini_esgf_data
+@pytest.mark.usefixtures("load_test_data")
 def test_wps_subset_c3s_cmip6(get_output, pywps_cfg):
     client = client_for(Service(processes=[Subset()], cfgfiles=[pywps_cfg]))
     datainputs = f"collection={C3S_CMIP6_MON_COLLECTION}"
@@ -58,6 +60,8 @@ def test_wps_subset_c3s_cmip6(get_output, pywps_cfg):
     assert "meta4" in get_output(resp.xml)["output"]
 
 
+@pytest.mark.mini_esgf_data
+@pytest.mark.usefixtures("load_test_data")
 @pytest.mark.xfail(reason="no cmip6 data in /pool/data")
 def test_wps_subset_c3s_cmip6_time_series(get_output, pywps_cfg):
     client = client_for(Service(processes=[Subset()], cfgfiles=[pywps_cfg]))
@@ -70,6 +74,8 @@ def test_wps_subset_c3s_cmip6_time_series(get_output, pywps_cfg):
     assert "meta4" in get_output(resp.xml)["output"]
 
 
+@pytest.mark.mini_esgf_data
+@pytest.mark.usefixtures("load_test_data")
 def test_wps_subset_c3s_cmip6_time_components(get_output, pywps_cfg):
     client = client_for(Service(processes=[Subset()], cfgfiles=[pywps_cfg]))
     datainputs = f"collection={C3S_CMIP6_MON_COLLECTION}"
@@ -84,6 +90,8 @@ def test_wps_subset_c3s_cmip6_time_components(get_output, pywps_cfg):
     assert b"year:2015,2016|month:01,02,03" in resp.data
 
 
+@pytest.mark.mini_esgf_data
+@pytest.mark.usefixtures("load_test_data")
 @pytest.mark.xfail(reason="no cmip6 data in /pool/data")
 def test_wps_subset_c3s_cmip6_metadata(get_output, pywps_cfg):
     client = client_for(Service(processes=[Subset()], cfgfiles=[pywps_cfg]))
@@ -116,6 +124,8 @@ def test_wps_subset_c3s_cmip6_metadata(get_output, pywps_cfg):
     assert "coordinates" not in ds.time_bnds.encoding
 
 
+@pytest.mark.mini_esgf_data
+@pytest.mark.usefixtures("load_test_data")
 def test_wps_subset_cmip6_prov(get_output, pywps_cfg):
     client = client_for(Service(processes=[Subset()], cfgfiles=[pywps_cfg]))
     datainputs = "collection=CMIP6.CMIP.IPSL.IPSL-CM6A-LR.historical.r1i1p1f1.Amon.rlds.gr.v20180803"
@@ -134,6 +144,8 @@ def test_wps_subset_cmip6_prov(get_output, pywps_cfg):
     )
 
 
+@pytest.mark.mini_esgf_data
+@pytest.mark.usefixtures("load_test_data")
 def test_wps_subset_cmip6_multiple_files_prov(get_output, pywps_cfg):
     client = client_for(Service(processes=[Subset()], cfgfiles=[pywps_cfg]))
     datainputs = "collection=CMIP6.CMIP.MPI-M.MPI-ESM1-2-HR.historical.r1i1p1f1.SImon.siconc.gn.latest"
@@ -151,6 +163,8 @@ def test_wps_subset_cmip6_multiple_files_prov(get_output, pywps_cfg):
     )
 
 
+@pytest.mark.mini_esgf_data
+@pytest.mark.usefixtures("load_test_data")
 def test_wps_subset_cmip6_original_files(get_output, pywps_cfg):
     client = client_for(Service(processes=[Subset()], cfgfiles=[pywps_cfg]))
     datainputs = "collection=CMIP6.CMIP.IPSL.IPSL-CM6A-LR.historical.r1i1p1f1.Amon.rlds.gr.v20180803"
@@ -162,6 +176,8 @@ def test_wps_subset_cmip6_original_files(get_output, pywps_cfg):
     assert "meta4" in get_output(resp.xml)["output"]
 
 
+@pytest.mark.mini_esgf_data
+@pytest.mark.usefixtures("load_test_data")
 def test_wps_subset_c3s_cmip6_collection_only(get_output, pywps_cfg):
     client = client_for(Service(processes=[Subset()], cfgfiles=[pywps_cfg]))
     datainputs = f"collection={C3S_CMIP6_MON_COLLECTION}"
@@ -181,6 +197,8 @@ def test_wps_subset_missing_collection(pywps_cfg):
     assert_process_exception(resp, code="MissingParameterValue")
 
 
+@pytest.mark.mini_esgf_data
+@pytest.mark.usefixtures("load_test_data")
 @pytest.mark.skip(reason="need a new test dataset")
 def test_wps_subset_time_invariant_dataset(get_output, pywps_cfg):
     client = client_for(Service(processes=[Subset()], cfgfiles=[pywps_cfg]))
@@ -193,6 +211,8 @@ def test_wps_subset_time_invariant_dataset(get_output, pywps_cfg):
     assert "meta4" in get_output(resp.xml)["output"]
 
 
+@pytest.mark.mini_esgf_data
+@pytest.mark.usefixtures("load_test_data")
 @pytest.mark.xfail(reason="no atlas v2.5 data in /pool/data")
 def test_wps_subset_c3s_atlas_v25_cmip5(get_output, pywps_cfg):
     client = client_for(Service(processes=[Subset()], cfgfiles=[pywps_cfg]))
@@ -210,6 +230,8 @@ def test_wps_subset_c3s_atlas_v25_cmip5(get_output, pywps_cfg):
     assert "roocs:pr_CMIP5_rcp26_mon_20200101-20200301.nc" in doc.get_provn()
 
 
+@pytest.mark.mini_esgf_data
+@pytest.mark.usefixtures("load_test_data")
 @pytest.mark.xfail(reason="no atlas v2.5 data in /pool/data")
 def test_wps_subset_c3s_atlas_v25_era5(get_output, pywps_cfg):
     client = client_for(Service(processes=[Subset()], cfgfiles=[pywps_cfg]))

--- a/tests/test_wps_subset.py
+++ b/tests/test_wps_subset.py
@@ -9,6 +9,8 @@ from pywps.tests import assert_process_exception, assert_response_success, clien
 from rook.processes.wps_subset import Subset
 from rook.utils.metalink_utils import parse_metalink
 
+pytestmark = [pytest.mark.mini_esgf_data, pytest.mark.usefixtures("load_test_data")]
+
 C3S_CMIP6_MON_COLLECTION = (
     "c3s-cmip6.ScenarioMIP.INM.INM-CM5-0.ssp245.r1i1p1f1.Amon.rlds.gr1.v20190619"
 )


### PR DESCRIPTION
## Overview

This PR cleans up the tests and uses the woodpecker synthetic test data.

## Related Issue / Discussion

## Additional Information


