### PR TITLE
use configured fixes provider only

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,12 @@ Changes
 Unreleased
 ==========
 
+* Made Woodpecker the default dataset fix provider while retaining the legacy
+  provider as a configuration-selected fallback.
+* Removed the temporary per-request fix-provider override. Smoke tests now use
+  the single provider selected in ``roocs.ini`` instead of running both
+  providers for every relevant case.
+
 1.2.3 (2026-07-08)
 ==================
 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -54,14 +54,14 @@ Fix provider backend
 --------------------
 
 Rook chooses the dataset fix provider internally from the ``roocs.ini``
-configuration. The default backend is ``legacy``.
+configuration. The default backend is ``woodpecker``.
 
-To use Woodpecker-backed fixes, set:
+To use the legacy fixes, set:
 
 .. code-block:: ini
 
    [fixes]
-   backend = woodpecker
+   backend = legacy
 
 Supported values are ``legacy`` and ``woodpecker``.
 

--- a/etc/sample-roocs.ini
+++ b/etc/sample-roocs.ini
@@ -22,3 +22,6 @@ base_dir = %(test_data)/gws/nopw/j04/cp4cds1_vol1/data/c3s-cordex
 
 [catalog]
 intake_catalog_url = https://raw.githubusercontent.com/cp4cds/c3s_34g_manifests/master/intake/catalogs/c3s.yaml
+
+[fixes]
+backend = woodpecker

--- a/src/rook/config.py
+++ b/src/rook/config.py
@@ -84,7 +84,7 @@ def get_storage_base(project: str) -> str | None:
 def get_fix_backend() -> str:
     """Return the configured dataset fix provider backend."""
     config = _get_section("fixes")
-    backend = config.get("backend", "legacy")
+    backend = config.get("backend", "woodpecker")
     allowed = {"legacy", "woodpecker"}
     if backend not in allowed:
         allowed_values = ", ".join(sorted(allowed))

--- a/src/rook/etc/roocs.ini
+++ b/src/rook/etc/roocs.ini
@@ -3,6 +3,9 @@
 [catalog]
 intake_catalog_url = https://raw.githubusercontent.com/cp4cds/c3s_34g_manifests/master/intake/catalogs/c3s.yaml
 
+[fixes]
+backend = woodpecker
+
 [s3]
 # Example:
 # These options are shared by NetCDF files and Zarr stores on S3.

--- a/src/rook/fixes/providers/__init__.py
+++ b/src/rook/fixes/providers/__init__.py
@@ -19,10 +19,9 @@ DATASET_FIX_PROVIDERS = {
 }
 
 
-def get_dataset_fix_provider(name=None):
+def get_dataset_fix_provider():
     """Return a configured dataset fix provider."""
-    if name is None:
-        name = get_fix_backend()
+    name = get_fix_backend()
 
     provider = DATASET_FIX_PROVIDERS.get(name)
     if provider is None:

--- a/src/rook/io/datasets.py
+++ b/src/rook/io/datasets.py
@@ -123,12 +123,12 @@ _OPENERS = {
 }
 
 
-def open_dataset(source: DatasetSource, fix_provider=None):
+def open_dataset(source: DatasetSource):
     """Open an xarray Dataset and apply catalog-specific fixes when available."""
     opener = _OPENERS[detect_format(source)]
     ds = opener(source, get_storage_options(source))
 
-    ds = apply_dataset_fix_policy(source, ds, fix_provider=fix_provider)
+    ds = apply_dataset_fix_policy(source, ds)
 
     return ds
 
@@ -138,12 +138,12 @@ def should_apply_dataset_fixes(source: DatasetSource) -> bool:
     return source.dataset_id is not None
 
 
-def apply_dataset_fix_policy(source: DatasetSource, ds, fix_provider=None):
+def apply_dataset_fix_policy(source: DatasetSource, ds):
     """Apply project-specific dataset fixes only when the source has catalog identity."""
     if not should_apply_dataset_fixes(source):
         return ds
 
-    provider = get_dataset_fix_provider(fix_provider)
+    provider = get_dataset_fix_provider()
     return provider.apply(ds, context=FixContext(dataset_id=source.dataset_id))
 
 

--- a/src/rook/operations/base.py
+++ b/src/rook/operations/base.py
@@ -63,20 +63,14 @@ class Operation:
 
     def calculate(self):
         self._add_output_config()
-        fix_provider = self.params.get("fix_provider")
-        operation_params = dict(self.params)
-        operation_params.pop("fix_provider", None)
-        norm_collection = normalise.normalise(
-            self.collection,
-            fix_provider=fix_provider,
-        )
+        norm_collection = normalise.normalise(self.collection)
 
         rs = normalise.ResultSet(vars())
 
         for dset, collection in norm_collection.items():
             rs.add(
                 dset,
-                process(self.get_operation_callable(), collection, **operation_params),
+                process(self.get_operation_callable(), collection, **self.params),
             )
 
         return rs

--- a/src/rook/operations/concat.py
+++ b/src/rook/operations/concat.py
@@ -41,22 +41,18 @@ def dataset_paths_by_id(sources):
     return collection
 
 
-def apply_concat_calendar_fix(ds, fix_provider=None):
+def apply_concat_calendar_fix(ds, provider):
     """Apply concat-specific preparation before grouped files are combined."""
-    if fix_provider is None:
-        fix_provider = get_dataset_fix_provider()
     context = FixContext(
         operation="concat",
         phase="prepare",
         recipe_id=WOODPECKER_CMIP6_DECADAL_RECIPE_ID,
     )
-    return fix_provider.prepare(ds, context=context)
+    return provider.prepare(ds, context=context)
 
 
-def apply_concat_dataset_fixes(collection, output_dir, fix_provider=None):
+def apply_concat_dataset_fixes(collection, output_dir, provider):
     """Apply concat-specific decadal fixes to each opened dataset."""
-    if fix_provider is None:
-        fix_provider = get_dataset_fix_provider()
     datasets = []
 
     for ds_id, ds in collection.items():
@@ -67,7 +63,7 @@ def apply_concat_dataset_fixes(collection, output_dir, fix_provider=None):
             output_dir=output_dir,
             recipe_id=WOODPECKER_CMIP6_DECADAL_RECIPE_ID,
         )
-        datasets.append(fix_provider.apply(ds, context=context))
+        datasets.append(provider.apply(ds, context=context))
 
     return datasets
 
@@ -117,13 +113,12 @@ class Concat(Operation):
             "time_components": time_components,
             "dims": dims,
             "apply_average": params.get("apply_average", False),
-            "fix_provider": params.get("fix_provider"),
             "ignore_undetected_dims": params.get("ignore_undetected_dims"),
         }
 
     def calculate(self):
         self._add_output_config()
-        fix_provider = get_dataset_fix_provider(self.params.get("fix_provider"))
+        provider = get_dataset_fix_provider()
         collection = dataset_paths_by_id(self.collection)
 
         # Concat intentionally does not use the base operation flow:
@@ -132,7 +127,7 @@ class Concat(Operation):
         # - apply dataset-id-aware fixes after each group has been opened.
         norm_collection = normalise.normalise_file_groups(
             collection,
-            prepare_dataset=lambda ds: apply_concat_calendar_fix(ds, fix_provider),
+            prepare_dataset=lambda ds: apply_concat_calendar_fix(ds, provider),
         )
 
         rs = normalise.ResultSet(vars())
@@ -140,7 +135,7 @@ class Concat(Operation):
         datasets = apply_concat_dataset_fixes(
             norm_collection,
             output_dir=self.params.get("output_dir", "."),
-            fix_provider=fix_provider,
+            provider=provider,
         )
         dims = self.params["dims"].value
         dim, standard_name = concat_dimension(dims)
@@ -162,7 +157,6 @@ def concat(
     split_method="time:auto",
     file_namer="standard",
     apply_average=False,
-    fix_provider=None,
 ):
     return Concat(
         collection=collection,
@@ -175,5 +169,4 @@ def concat(
         split_method=split_method,
         file_namer=file_namer,
         apply_average=apply_average,
-        fix_provider=fix_provider,
     ).calculate()

--- a/src/rook/operations/normalise.py
+++ b/src/rook/operations/normalise.py
@@ -10,13 +10,13 @@ import xarray as xr
 from rook.io.datasets import open_dataset
 
 
-def normalise(collection, *, fix_provider=None):
+def normalise(collection):
     """Open input collections."""
     logger.info(f"Working on datasets: {collection}")
     norm_collection = OrderedDict()
 
     for source in collection:
-        ds = open_dataset(source, fix_provider=fix_provider)
+        ds = open_dataset(source)
         norm_collection[source.key] = ds
 
     return norm_collection

--- a/src/rook/operations/subset.py
+++ b/src/rook/operations/subset.py
@@ -23,7 +23,6 @@ class Subset(Operation):
             "time_components": time_components_parameter.TimeComponentsParameter(
                 params.get("time_components")
             ),
-            "fix_provider": params.get("fix_provider"),
         }
 
     def get_operation_callable(self):
@@ -36,7 +35,6 @@ def subset(
     area=None,
     level=None,
     time_components=None,
-    fix_provider=None,
     output_dir=None,
     output_type="netcdf",
     split_method="time:auto",

--- a/src/rook/processes/wps_concat.py
+++ b/src/rook/processes/wps_concat.py
@@ -84,18 +84,6 @@ class Concat(Process):
                 min_occurs=1,
                 max_occurs=1,
             ),
-            LiteralInput(
-                "fix_provider",
-                "Fix Provider",
-                abstract="Temporary fix provider override for integration smoke and parity tests.",
-                allowed_values=[
-                    "legacy",
-                    "woodpecker",
-                ],
-                data_type="string",
-                min_occurs=0,
-                max_occurs=1,
-            ),
         ]
         outputs = [
             ComplexOutput(
@@ -158,9 +146,6 @@ class Concat(Process):
             ),
             "dims": parse_wps_input(
                 request.inputs, "dims", as_sequence=True, default=None
-            ),
-            "fix_provider": parse_wps_input(
-                request.inputs, "fix_provider", default=None
             ),
         }
 

--- a/src/rook/processes/wps_subset.py
+++ b/src/rook/processes/wps_subset.py
@@ -86,18 +86,6 @@ class Subset(Process):
                 max_occurs=1,
             ),
             LiteralInput(
-                "fix_provider",
-                "Fix Provider",
-                abstract="Temporary fix provider override for integration smoke and parity tests.",
-                allowed_values=[
-                    "legacy",
-                    "woodpecker",
-                ],
-                data_type="string",
-                min_occurs=0,
-                max_occurs=1,
-            ),
-            LiteralInput(
                 "original_files",
                 "Original Files",
                 data_type="boolean",
@@ -165,9 +153,6 @@ class Subset(Process):
             ),
             "level": parse_wps_input(request.inputs, "level", default=None),
             "area": parse_wps_input(request.inputs, "area", default=None),
-            "fix_provider": parse_wps_input(
-                request.inputs, "fix_provider", default=None
-            ),
         }
 
         # Plan the request before processing or returning original files

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,6 +84,9 @@ def write_roocs_cfg(stratus):
     [clisops:write]
     file_size_limit = 100KB
 
+    [fixes]
+    backend = woodpecker
+
     [project:cmip5]
     base_dir = {{ base_dir }}/badc/cmip5/data/cmip5
     use_inventory = False

--- a/tests/smoke/README.md
+++ b/tests/smoke/README.md
@@ -56,9 +56,10 @@ OR
 make smoke
 ```
 
-The CMIP6 decadal and atlas smoke tests call the relevant process with the
-temporary `fix_provider` input for both `legacy` and `woodpecker`. This
-overrides the `roocs.ini` default only for those smoke requests.
+The smoke suite uses the single fix provider selected in `roocs.ini`. The
+default is `woodpecker`. To run the same suite as a legacy compatibility check,
+set `[fixes] backend = legacy` in the service configuration before starting the
+service.
 
 ## Run smoke tests on a deployed pywps server
 

--- a/tests/smoke/test_smoke_checks.py
+++ b/tests/smoke/test_smoke_checks.py
@@ -272,24 +272,16 @@ WF_C3S_CMIP6_DECADAL_2 = json.dumps(
 )
 
 
-def concat_inputs(collections, fix_provider, time=None):
+def concat_inputs(collections, time=None):
     inputs = [("collection", collection) for collection in collections]
-    inputs.extend(
-        [
-            ("dims", "realization"),
-            ("fix_provider", fix_provider),
-        ]
-    )
+    inputs.append(("dims", "realization"))
     if time is not None:
         inputs.append(("time", time))
     return inputs
 
 
-def subset_inputs(collection, fix_provider, **params):
-    inputs = [
-        ("collection", collection),
-        ("fix_provider", fix_provider),
-    ]
+def subset_inputs(collection, **params):
+    inputs = [("collection", collection)]
     inputs.extend((name, value) for name, value in params.items() if value is not None)
     return inputs
 
@@ -752,11 +744,9 @@ def test_smoke_execute_c3s_cordex_orchestrate(wps):
     )
 
 
-@pytest.mark.parametrize("fix_provider", ("legacy", "woodpecker"))
-def test_smoke_execute_c3s_cmip6_decadal_concat(wps, fix_provider):
+def test_smoke_execute_c3s_cmip6_decadal_concat(wps):
     inputs = concat_inputs(
         C3S_CMIP6_DECADAL_COLLECTIONS,
-        fix_provider,
         time="1995/1995",
     )
     urls = wps.execute("concat", inputs)
@@ -765,11 +755,9 @@ def test_smoke_execute_c3s_cmip6_decadal_concat(wps, fix_provider):
     assert "19951116-19951216.nc" in urls[0]
 
 
-@pytest.mark.parametrize("fix_provider", ("legacy", "woodpecker"))
-def test_smoke_execute_c3s_cmip6_decadal_fix_calendar_concat(wps, fix_provider):
+def test_smoke_execute_c3s_cmip6_decadal_fix_calendar_concat(wps):
     inputs = concat_inputs(
         C3S_CMIP6_DECADAL_CALENDAR_COLLECTIONS,
-        fix_provider,
         time="1985-01-01/1985-12-31",
     )
     urls = wps.execute("concat", inputs)
@@ -778,9 +766,8 @@ def test_smoke_execute_c3s_cmip6_decadal_fix_calendar_concat(wps, fix_provider):
     assert "19850116-19851216.nc" in urls[0]
 
 
-@pytest.mark.parametrize("fix_provider", ("legacy", "woodpecker"))
-def test_smoke_execute_c3s_ipcc_atlas_cmip5_subset(wps, fix_provider):
-    inputs = subset_inputs(C3S_IPCC_ATLAS_CMIP5_COLLECTION, fix_provider)
+def test_smoke_execute_c3s_ipcc_atlas_cmip5_subset(wps):
+    inputs = subset_inputs(C3S_IPCC_ATLAS_CMIP5_COLLECTION)
     urls = wps.execute("subset", inputs)
     assert len(urls) == 1
     assert "data.mips.climate.copernicus.eu" in urls[0]
@@ -788,9 +775,8 @@ def test_smoke_execute_c3s_ipcc_atlas_cmip5_subset(wps, fix_provider):
     assert "tnn_CMIP5_rcp45_mon_200601-210012.nc" in urls[0]
 
 
-@pytest.mark.parametrize("fix_provider", ("legacy", "woodpecker"))
-def test_smoke_execute_c3s_ipcc_atlas_cmip6_subset(wps, fix_provider):
-    inputs = subset_inputs(C3S_IPCC_ATLAS_CMIP6_COLLECTION, fix_provider)
+def test_smoke_execute_c3s_ipcc_atlas_cmip6_subset(wps):
+    inputs = subset_inputs(C3S_IPCC_ATLAS_CMIP6_COLLECTION)
     urls = wps.execute("subset", inputs)
     assert len(urls) == 1
     assert "data.mips.climate.copernicus.eu" in urls[0]
@@ -798,9 +784,8 @@ def test_smoke_execute_c3s_ipcc_atlas_cmip6_subset(wps, fix_provider):
     assert "tnn_CMIP6_historical_mon_185001-201412.nc" in urls[0]
 
 
-@pytest.mark.parametrize("fix_provider", ("legacy", "woodpecker"))
-def test_smoke_execute_c3s_ipcc_atlas_cordex_subset(wps, fix_provider):
-    inputs = subset_inputs(C3S_IPCC_ATLAS_CORDEX_COLLECTION, fix_provider)
+def test_smoke_execute_c3s_ipcc_atlas_cordex_subset(wps):
+    inputs = subset_inputs(C3S_IPCC_ATLAS_CORDEX_COLLECTION)
     urls = wps.execute("subset", inputs)
     assert len(urls) == 1
     assert "data.mips.climate.copernicus.eu" in urls[0]
@@ -808,11 +793,9 @@ def test_smoke_execute_c3s_ipcc_atlas_cordex_subset(wps, fix_provider):
     assert "tnn_CORDEX-AFR_historical_mon_197001-200512.nc" in urls[0]
 
 
-@pytest.mark.parametrize("fix_provider", ("legacy", "woodpecker"))
-def test_smoke_execute_c3s_cica_atlas_cmip6_subset(wps, fix_provider):
+def test_smoke_execute_c3s_cica_atlas_cmip6_subset(wps):
     inputs = subset_inputs(
         C3S_CICA_ATLAS_CMIP6_COLLECTION,
-        fix_provider,
         time="2000/2000",
     )
     urls = wps.execute("subset", inputs)
@@ -822,11 +805,9 @@ def test_smoke_execute_c3s_cica_atlas_cmip6_subset(wps, fix_provider):
     assert "cd_CMIP6_historical_yr_20000101-20000101.nc" in urls[0]
 
 
-@pytest.mark.parametrize("fix_provider", ("legacy", "woodpecker"))
-def test_smoke_execute_c3s_cica_atlas_cordex_subset(wps, fix_provider):
+def test_smoke_execute_c3s_cica_atlas_cordex_subset(wps):
     inputs = subset_inputs(
         C3S_CICA_ATLAS_CORDEX_COLLECTION,
-        fix_provider,
         time="2000/2000",
     )
     urls = wps.execute("subset", inputs)
@@ -836,9 +817,8 @@ def test_smoke_execute_c3s_cica_atlas_cordex_subset(wps, fix_provider):
     assert "cdd_CORDEX-CORE_historical_yr_20000101-20000101.nc" in urls[0]
 
 
-@pytest.mark.parametrize("fix_provider", ("legacy", "woodpecker"))
-def test_smoke_execute_c3s_cica_atlas_era5_subset_no_time_param(wps, fix_provider):
-    inputs = subset_inputs(C3S_CICA_ATLAS_ERA5_COLLECTION, fix_provider)
+def test_smoke_execute_c3s_cica_atlas_era5_subset_no_time_param(wps):
+    inputs = subset_inputs(C3S_CICA_ATLAS_ERA5_COLLECTION)
     urls = wps.execute("subset", inputs)
     assert len(urls) == 1
     assert "data.mips.climate.copernicus.eu" in urls[0]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -45,10 +45,10 @@ def test_get_storage_base_falls_back_to_local_project_root(monkeypatch):
     assert config.get_storage_base("demo") == "/data/demo"
 
 
-def test_get_fix_backend_defaults_to_legacy(monkeypatch):
+def test_get_fix_backend_defaults_to_woodpecker(monkeypatch):
     monkeypatch.setattr(config, "_CONFIG", {})
 
-    assert config.get_fix_backend() == "legacy"
+    assert config.get_fix_backend() == "woodpecker"
 
 
 def test_get_fix_backend_uses_fixes_config(monkeypatch):

--- a/tests/test_fixes_providers.py
+++ b/tests/test_fixes_providers.py
@@ -12,7 +12,9 @@ from rook.fixes.providers import (
 )
 
 
-def test_get_dataset_fix_provider_returns_legacy_provider_by_default():
+def test_get_dataset_fix_provider_returns_configured_legacy_provider(monkeypatch):
+    monkeypatch.setattr("rook.fixes.providers.get_fix_backend", lambda: "legacy")
+
     provider = get_dataset_fix_provider()
 
     assert isinstance(provider, LegacyDatasetFixProvider)
@@ -124,13 +126,6 @@ def test_legacy_provider_leaves_unknown_dataset_unchanged():
     )
 
     assert result is source
-
-
-def test_get_dataset_fix_provider_returns_woodpecker_provider():
-    provider = get_dataset_fix_provider("woodpecker")
-
-    assert isinstance(provider, WoodpeckerDatasetFixProvider)
-    assert provider.name == "woodpecker"
 
 
 def test_woodpecker_provider_prepares_decadal_concat_dataset(monkeypatch):
@@ -272,8 +267,3 @@ def test_woodpecker_provider_leaves_unknown_dataset_unchanged(monkeypatch):
     )
 
     assert result is source
-
-
-def test_get_dataset_fix_provider_rejects_unknown_provider():
-    with pytest.raises(ValueError, match="Unsupported dataset fix provider"):
-        get_dataset_fix_provider("unknown")

--- a/tests/test_io_datasets.py
+++ b/tests/test_io_datasets.py
@@ -243,7 +243,7 @@ def test_open_dataset_keeps_local_netcdf_path(tmp_path, monkeypatch):
     monkeypatch.setattr(
         helpers,
         "get_dataset_fix_provider",
-        lambda provider_name=None: FakeProvider(result=expected),
+        lambda: FakeProvider(result=expected),
     )
 
     result = helpers.open_dataset(source("project.dataset", [str(path)]))

--- a/tests/test_io_datasets.py
+++ b/tests/test_io_datasets.py
@@ -57,7 +57,7 @@ def test_open_dataset_applies_fixes(monkeypatch):
     monkeypatch.setattr(
         helpers,
         "get_dataset_fix_provider",
-        lambda provider_name=None: FakeProvider(provider_calls),
+        lambda: FakeProvider(provider_calls),
     )
     monkeypatch.setattr(helpers, "is_kerchunk_file", lambda _: False)
 
@@ -80,7 +80,7 @@ def test_open_dataset_applies_catalog_fixes_without_external_switch(monkeypatch)
     monkeypatch.setattr(
         helpers,
         "get_dataset_fix_provider",
-        lambda provider_name=None: FakeProvider(provider_calls),
+        lambda: FakeProvider(provider_calls),
     )
     monkeypatch.setattr(helpers, "is_kerchunk_file", lambda _: False)
 
@@ -130,32 +130,13 @@ def test_apply_dataset_fix_policy_uses_dataset_id(monkeypatch):
     monkeypatch.setattr(
         helpers,
         "get_dataset_fix_provider",
-        lambda provider_name=None: FakeProvider(calls),
+        lambda: FakeProvider(calls),
     )
 
     result = helpers.apply_dataset_fix_policy(source("project.dataset", "a.nc"), "DS")
 
     assert result == "FIXED"
     assert calls == [("project.dataset", "DS")]
-
-
-def test_apply_dataset_fix_policy_uses_requested_provider(monkeypatch):
-    calls = []
-
-    def fake_get_provider(provider_name=None):
-        calls.append(provider_name)
-        return FakeProvider()
-
-    monkeypatch.setattr(helpers, "get_dataset_fix_provider", fake_get_provider)
-
-    result = helpers.apply_dataset_fix_policy(
-        source("project.dataset", "a.nc"),
-        "DS",
-        fix_provider="woodpecker",
-    )
-
-    assert result == "FIXED"
-    assert calls == ["woodpecker"]
 
 
 def test_apply_dataset_fix_policy_leaves_direct_sources_unchanged(monkeypatch):

--- a/tests/test_operations_execution.py
+++ b/tests/test_operations_execution.py
@@ -173,7 +173,9 @@ def test_subset_uses_base_operation_calculate():
     assert Subset.calculate is Operation.calculate
 
 
-def test_base_operation_uses_fix_provider_only_for_dataset_opening(monkeypatch):
+def test_base_operation_uses_configured_fix_provider_during_dataset_opening(
+    monkeypatch,
+):
     calls = []
     operation_dataset = object()
 
@@ -184,9 +186,7 @@ def test_base_operation_uses_fix_provider_only_for_dataset_opening(monkeypatch):
     monkeypatch.setattr(
         operation_base.normalise,
         "normalise",
-        lambda collection, fix_provider=None: calls.append(
-            ("normalise", collection, fix_provider)
-        )
+        lambda collection: calls.append(("normalise", collection))
         or {"dataset": operation_dataset},
     )
     monkeypatch.setattr(
@@ -198,13 +198,12 @@ def test_base_operation_uses_fix_provider_only_for_dataset_opening(monkeypatch):
 
     source = DatasetSource("dataset.id", "input.nc")
 
-    result = Subset(collection=[source], fix_provider="woodpecker").calculate()
+    result = Subset(collection=[source]).calculate()
 
     assert result.file_uris == []
-    assert calls[0] == ("normalise", (source,), "woodpecker")
+    assert calls[0] == ("normalise", (source,))
     assert calls[1][0] == "process"
     assert calls[1][1] is operation_dataset
-    assert "fix_provider" not in calls[1][2]
     assert calls[1][2]["output_type"] == "netcdf"
     assert calls[1][2]["output_dir"] is None
     assert calls[1][2]["split_method"] == "time:auto"

--- a/tests/test_ops_concat.py
+++ b/tests/test_ops_concat.py
@@ -19,7 +19,7 @@ def test_concat_dataset_paths_are_keyed_by_catalog_id(monkeypatch):
     assert collection["derived.dataset"] == ("direct.nc",)
 
 
-def test_apply_concat_calendar_fix_applies_decadal_calendar_fix(monkeypatch):
+def test_apply_concat_calendar_fix_applies_decadal_calendar_fix():
     calls = []
     source = xr.Dataset(attrs={"source": "input"})
 
@@ -34,7 +34,7 @@ def test_apply_concat_calendar_fix_applies_decadal_calendar_fix(monkeypatch):
     assert calls == [("input", "concat", "prepare")]
 
 
-def test_apply_concat_dataset_fixes_preserves_dataset_identity(monkeypatch, tmp_path):
+def test_apply_concat_dataset_fixes_preserves_dataset_identity(tmp_path):
     calls = []
     first = xr.Dataset(attrs={"source": "first"})
     second = xr.Dataset(attrs={"source": "second"})
@@ -44,11 +44,10 @@ def test_apply_concat_dataset_fixes_preserves_dataset_identity(monkeypatch, tmp_
             calls.append((context.dataset_id, ds.attrs["source"], context.output_dir))
             return ds.assign_attrs(fixed=context.dataset_id)
 
-    monkeypatch.setattr(concat_mod, "get_dataset_fix_provider", lambda: FakeProvider())
-
     datasets = concat_mod.apply_concat_dataset_fixes(
         {"first.id": first, "second.id": second},
         output_dir=tmp_path.as_posix(),
+        provider=FakeProvider(),
     )
 
     assert calls == [
@@ -56,45 +55,6 @@ def test_apply_concat_dataset_fixes_preserves_dataset_identity(monkeypatch, tmp_
         ("second.id", "second", tmp_path.as_posix()),
     ]
     assert [ds.attrs["fixed"] for ds in datasets] == ["first.id", "second.id"]
-
-
-def test_apply_concat_dataset_fixes_uses_configured_provider(monkeypatch, tmp_path):
-    calls = []
-    source = xr.Dataset(attrs={"source": "first"})
-
-    class FakeProvider:
-        def apply(self, ds, *, context=None):
-            calls.append(
-                (
-                    context.dataset_id,
-                    ds.attrs["source"],
-                    context.output_dir,
-                    context.recipe_id,
-                )
-            )
-            return ds.assign_attrs(fixed_with="woodpecker")
-
-    monkeypatch.setattr(
-        concat_mod,
-        "get_dataset_fix_provider",
-        lambda: calls.append(("provider",)) or FakeProvider(),
-    )
-
-    datasets = concat_mod.apply_concat_dataset_fixes(
-        {"first.id": source},
-        output_dir=tmp_path.as_posix(),
-    )
-
-    assert calls == [
-        ("provider",),
-        (
-            "first.id",
-            "first",
-            tmp_path.as_posix(),
-            concat_mod.WOODPECKER_CMIP6_DECADAL_RECIPE_ID,
-        ),
-    ]
-    assert datasets[0].attrs["fixed_with"] == "woodpecker"
 
 
 def test_concat_reuses_configured_fix_provider(monkeypatch, tmp_path):
@@ -116,7 +76,7 @@ def test_concat_reuses_configured_fix_provider(monkeypatch, tmp_path):
     monkeypatch.setattr(
         concat_mod,
         "get_dataset_fix_provider",
-        lambda name=None: calls.append(("provider", name)) or fake_provider,
+        lambda: calls.append(("provider",)) or fake_provider,
     )
     monkeypatch.setattr(
         concat_mod.normalise,
@@ -126,8 +86,8 @@ def test_concat_reuses_configured_fix_provider(monkeypatch, tmp_path):
     monkeypatch.setattr(
         concat_mod,
         "apply_concat_dataset_fixes",
-        lambda collection, output_dir, fix_provider=None: calls.append(
-            (collection, output_dir, fix_provider)
+        lambda collection, output_dir, provider: calls.append(
+            (collection, output_dir, provider)
         )
         or [combined],
     )
@@ -150,7 +110,7 @@ def test_concat_reuses_configured_fix_provider(monkeypatch, tmp_path):
 
     assert result.file_uris == ["https://example.com/fixed.nc"]
     assert calls == [
-        ("provider", None),
+        ("provider",),
         ("prepare", source, "concat", "prepare"),
         (
             {"dataset.id": source},
@@ -160,66 +120,17 @@ def test_concat_reuses_configured_fix_provider(monkeypatch, tmp_path):
     ]
 
 
-def test_concat_can_override_configured_fix_provider(monkeypatch, tmp_path):
-    calls = []
-    source = DatasetSource("dataset.id", ["input.nc"])
-    combined = xr.Dataset({"tas": ("realization", [1.0])})
-    final = ["https://example.com/fixed.nc"]
-
-    class FakeProvider:
-        def prepare(self, ds, *, context=None):
-            return ds
-
-    fake_provider = FakeProvider()
-
-    monkeypatch.setattr(
-        concat_mod, "dataset_paths_by_id", lambda collection: collection
-    )
-    monkeypatch.setattr(
-        concat_mod,
-        "get_dataset_fix_provider",
-        lambda name=None: calls.append(("provider", name)) or fake_provider,
-    )
-    monkeypatch.setattr(
-        concat_mod.normalise,
-        "normalise_file_groups",
-        lambda collection, prepare_dataset: {"dataset.id": prepare_dataset(source)},
-    )
-    monkeypatch.setattr(
-        concat_mod,
-        "apply_concat_dataset_fixes",
-        lambda collection, output_dir, fix_provider=None: [combined],
-    )
-    monkeypatch.setattr(
-        concat_mod,
-        "combine_concat_datasets",
-        lambda datasets, dim, standard_name: combined,
-    )
-    monkeypatch.setattr(
-        concat_mod,
-        "finalise_concat_output",
-        lambda ds, params, dim: final,
-    )
-
-    result = concat_mod.concat(
-        collection=[source],
-        dims=["realization"],
-        output_dir=tmp_path.as_posix(),
-        fix_provider="woodpecker",
-    )
-
-    assert result.file_uris == ["https://example.com/fixed.nc"]
-    assert calls == [("provider", "woodpecker")]
-
-
 def test_concat_uses_synthetic_decadal_files_with_woodpecker_provider(
-    tmp_path, synthetic_cmip6_decadal_source
+    monkeypatch, tmp_path, synthetic_cmip6_decadal_source
 ):
+    monkeypatch.setattr(
+        "rook.fixes.providers.get_fix_backend", lambda: "woodpecker"
+    )
+
     result = concat_mod.concat(
         collection=[synthetic_cmip6_decadal_source],
         dims=["realization"],
         output_dir=tmp_path.as_posix(),
-        fix_provider="woodpecker",
     )
 
     assert len(result.file_uris) == 1

--- a/tests/test_wps_concat.py
+++ b/tests/test_wps_concat.py
@@ -5,11 +5,11 @@ from pywps.tests import assert_response_success, client_for
 from rook.processes.wps_concat import Concat
 
 
-def test_wps_concat_exposes_fix_provider_override_not_fix_backend():
+def test_wps_concat_does_not_expose_fix_provider_configuration():
     process = Concat()
     inputs = [inp.identifier for inp in process.inputs]
 
-    assert "fix_provider" in inputs
+    assert "fix_provider" not in inputs
     assert "fix_backend" not in inputs
 
 

--- a/tests/test_wps_subset.py
+++ b/tests/test_wps_subset.py
@@ -24,11 +24,11 @@ C3S_ATLAS_V25_ERA5_COLLECTION = "c3s-cica-atlas.psl.ERA5.mon.v25"
 C3S_ATLAS_V25_CORDEX_COLLECTION = "c3s-cica-atlas.huss.CORDEX-CORE.historical.mon.v25"
 
 
-def test_wps_subset_exposes_fix_provider_override():
+def test_wps_subset_does_not_expose_fix_provider_configuration():
     process = Subset()
     inputs = [inp.identifier for inp in process.inputs]
 
-    assert "fix_provider" in inputs
+    assert "fix_provider" not in inputs
     assert "fix_backend" not in inputs
 
 


### PR DESCRIPTION
## Overview

This PR updates the fixes backend usage.

Changes:

* Only use one fixes backend as configured ... no overwrite.
* No parallel smoke tests for legacy and woodpecker backend.
* "woodpecker" is the default backend.

## Related Issue / Discussion

## Additional Information

