### PR TITLE
Dev health

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,9 @@ Unreleased
 * Added the lightweight synchronous ``health`` WPS process for service health
   checks. Its raw output is ``ROOK_HEALTH_OK`` on success; failed checks return
   an OGC exception with an explanation and omit the success marker. Deeper
-  operational checks can be added later without changing this contract.
+  operational checks can be added later without changing this contract. Named
+  projects can be configured to verify read access to their
+  ``base_dir/.health-check.txt`` sentinel files.
 
 * Made Woodpecker the default dataset fix provider while retaining the legacy
   provider as a configuration-selected fallback.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,9 +4,10 @@ Changes
 Unreleased
 ==========
 
-* Added the lightweight ``health`` WPS process for service health checks. It
-  currently verifies that Rook can execute a process and returns ``status=ok``;
-  deeper operational checks can be added later without changing its identifier.
+* Added the lightweight synchronous ``health`` WPS process for service health
+  checks. Its raw output is ``ROOK_HEALTH_OK`` on success; failed checks return
+  an OGC exception with an explanation and omit the success marker. Deeper
+  operational checks can be added later without changing this contract.
 
 * Made Woodpecker the default dataset fix provider while retaining the legacy
   provider as a configuration-selected fallback.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,10 @@ Changes
 Unreleased
 ==========
 
+* Added the lightweight ``health`` WPS process for service health checks. It
+  currently verifies that Rook can execute a process and returns ``status=ok``;
+  deeper operational checks can be added later without changing its identifier.
+
 * Made Woodpecker the default dataset fix provider while retaining the legacy
   provider as a configuration-selected fallback.
 * Removed the temporary per-request fix-provider override. Smoke tests now use

--- a/README.rst
+++ b/README.rst
@@ -54,6 +54,19 @@ http://localhost:5000/wps?service=WPS&version=1.0.0&request=GetCapabilities
 
 Use ``make stop`` to stop the local service.
 
+Health Check
+------------
+
+Rook provides a lightweight synchronous WPS process for health monitoring:
+
+.. code-block:: text
+
+        /wps?service=WPS&version=1.0.0&request=Execute&identifier=health&RawDataOutput=status
+
+A healthy response is plain text containing exactly ``ROOK_HEALTH_OK``. Failed
+checks omit that marker and return an OGC exception with a concise explanation.
+Monitoring should therefore require an exact match of the success marker.
+
 Documentation
 -------------
 

--- a/README.rst
+++ b/README.rst
@@ -67,6 +67,22 @@ A healthy response is plain text containing exactly ``ROOK_HEALTH_OK``. Failed
 checks omit that marker and return an OGC exception with a concise explanation.
 Monitoring should therefore require an exact match of the success marker.
 
+Optional filesystem checks select projects configured in ``roocs.ini``:
+
+.. code-block:: ini
+
+        [health]
+        projects = c3s-cordex, c3s-cmip6, c3s-cica-atlas
+
+For each selected project, the health process takes its existing ``base_dir``
+and opens ``base_dir/.health-check.txt`` to read one byte. For example,
+``c3s-cordex`` checks the sentinel below ``[project:c3s-cordex]``. This tests
+actual read access to mounts such as Lustre without duplicating paths, loading
+a dataset, or searching large directory trees. All selected projects must be
+readable. Public failure messages use project names but do not expose
+filesystem paths. With no projects configured, the process only checks that
+Rook can execute it.
+
 Documentation
 -------------
 

--- a/TODO.md
+++ b/TODO.md
@@ -174,9 +174,8 @@ they should stay visible:
   and parameter variants easier to tweak;
 - refactor the dashboard process;
 - refactor the usage process;
-- define and implement a health-check process after its operational contract,
-  checks, and response format have been agreed; this is not a blocker for the
-  immediate production release;
+- extend the lightweight `health` WPS process with deeper operational checks
+  after their contract and failure behavior have been agreed;
 - clean up all WPS process modules in general.
 
 ## Synthetic Test Data

--- a/docs/source/processes.rst
+++ b/docs/source/processes.rst
@@ -32,6 +32,20 @@ request:
 The monitoring layer should consider the response healthy only when its body
 matches ``ROOK_HEALTH_OK`` exactly.
 
+Filesystem availability can be checked by selecting projects in ``roocs.ini``:
+
+.. code-block:: ini
+
+   [health]
+   projects = c3s-cordex, c3s-cmip6, c3s-cica-atlas
+
+For each selected project, ``base_dir/.health-check.txt`` is opened and one byte
+is read. The ``base_dir`` comes from the existing ``[project:<name>]`` section,
+so filesystem paths are not repeated in the health configuration. All selected
+projects must be readable. Failure messages identify the project without
+exposing the filesystem path. If no projects are configured, only process
+execution is checked.
+
 Subset
 ------
 

--- a/docs/source/processes.rst
+++ b/docs/source/processes.rst
@@ -7,6 +7,21 @@ Processes
     :local:
     :depth: 1
 
+Health
+------
+
+.. autoprocess:: rook.processes.wps_health.Health
+    :docstring:
+    :skiplines: 1
+    :noindex:
+
+The process has no inputs and returns the literal output ``status=ok`` when
+Rook can execute it. An HTTP health endpoint can delegate to:
+
+.. code-block:: text
+
+   /wps?service=WPS&version=1.0.0&request=Execute&identifier=health
+
 Subset
 ------
 

--- a/docs/source/processes.rst
+++ b/docs/source/processes.rst
@@ -16,7 +16,10 @@ Health
     :noindex:
 
 The process has no inputs and returns the literal output ``status=ok`` when
-Rook can execute it. An HTTP health endpoint can delegate to:
+Rook can execute it. It must be executed synchronously so the health request
+stays in the web service and responds immediately instead of being submitted to
+the batch system. An HTTP health endpoint can delegate to this synchronous
+request:
 
 .. code-block:: text
 

--- a/docs/source/processes.rst
+++ b/docs/source/processes.rst
@@ -15,15 +15,22 @@ Health
     :skiplines: 1
     :noindex:
 
-The process has no inputs and returns the literal output ``status=ok`` when
-Rook can execute it. It must be executed synchronously so the health request
-stays in the web service and responds immediately instead of being submitted to
-the batch system. An HTTP health endpoint can delegate to this synchronous
+The process has no inputs. Its raw output is exactly ``ROOK_HEALTH_OK`` when
+Rook can execute it and all configured checks pass. A failed check produces an
+OGC exception response containing a concise explanation and does not include
+the success marker.
+
+It must be executed synchronously so the health request stays in the web
+service and responds immediately instead of being submitted to the batch
+system. An HTTP health endpoint can delegate to this synchronous raw-output
 request:
 
 .. code-block:: text
 
-   /wps?service=WPS&version=1.0.0&request=Execute&identifier=health
+   /wps?service=WPS&version=1.0.0&request=Execute&identifier=health&RawDataOutput=status
+
+The monitoring layer should consider the response healthy only when its body
+matches ``ROOK_HEALTH_OK`` exactly.
 
 Subset
 ------

--- a/etc/sample-roocs.ini
+++ b/etc/sample-roocs.ini
@@ -25,3 +25,9 @@ intake_catalog_url = https://raw.githubusercontent.com/cp4cds/c3s_34g_manifests/
 
 [fixes]
 backend = woodpecker
+
+[health]
+# Comma-separated project names whose base_dir/.health-check.txt sentinel must
+# be readable. For example, the first entry below uses the base_dir configured
+# in [project:c3s-cordex].
+# projects = c3s-cordex, c3s-cmip6, c3s-cica-atlas

--- a/src/rook/config.py
+++ b/src/rook/config.py
@@ -81,6 +81,35 @@ def get_storage_base(project: str) -> str | None:
     )
 
 
+def get_health_readable_files() -> dict[str, str]:
+    """Return project sentinel files that the health process must read."""
+    config = _get_section("health")
+    raw_projects = config.get("projects")
+    if not raw_projects:
+        return {}
+
+    if not isinstance(raw_projects, str):
+        raise ConfigurationError(
+            "Configuration option 'health.projects' must be a comma-separated list."
+        )
+
+    projects = [project.strip() for project in raw_projects.split(",")]
+    if any(not project for project in projects):
+        raise ConfigurationError(
+            "Configuration option 'health.projects' contains an empty project name."
+        )
+
+    files = {}
+    for project in projects:
+        base_dir = get_project_config(project).get("base_dir")
+        if not isinstance(base_dir, str) or not base_dir.strip():
+            raise ConfigurationError(
+                f"Health project '{project}' must define a non-empty base_dir."
+            )
+        files[project] = str(Path(base_dir) / ".health-check.txt")
+    return files
+
+
 def get_fix_backend() -> str:
     """Return the configured dataset fix provider backend."""
     config = _get_section("fixes")

--- a/src/rook/etc/roocs.ini
+++ b/src/rook/etc/roocs.ini
@@ -6,6 +6,11 @@ intake_catalog_url = https://raw.githubusercontent.com/cp4cds/c3s_34g_manifests/
 [fixes]
 backend = woodpecker
 
+[health]
+# Comma-separated project names whose base_dir/.health-check.txt sentinel must
+# be readable, for example: c3s-cordex, c3s-cmip6, c3s-cica-atlas
+# projects = c3s-cordex
+
 [s3]
 # Example:
 # These options are shared by NetCDF files and Zarr stores on S3.

--- a/src/rook/exceptions.py
+++ b/src/rook/exceptions.py
@@ -1,2 +1,6 @@
 class WorkflowValidationError(Exception):
     pass
+
+
+class HealthCheckError(RuntimeError):
+    """Raised when an operational health check fails."""

--- a/src/rook/processes/__init__.py
+++ b/src/rook/processes/__init__.py
@@ -6,12 +6,14 @@ from .wps_average_time import AverageByTime
 from .wps_average_weighted import WeightedAverage
 from .wps_concat import Concat
 from .wps_dashboard import DashboardProcess
+from .wps_health import Health
 from .wps_orchestrate import Orchestrate
 from .wps_regrid import Regrid
 from .wps_subset import Subset
 from .wps_usage import Usage
 
 processes = [
+    Health(),
     Usage(),
     DashboardProcess(),
     Subset(),

--- a/src/rook/processes/wps_health.py
+++ b/src/rook/processes/wps_health.py
@@ -7,12 +7,9 @@ from pywps.app.Common import Metadata
 from pywps.app.exceptions import ProcessError
 
 from rook.config import ConfigurationError, get_health_readable_files
+from rook.exceptions import HealthCheckError
 
 HEALTHY_RESPONSE = "ROOK_HEALTH_OK"
-
-
-class HealthCheckError(RuntimeError):
-    """Raised when an operational health check fails."""
 
 
 def run_health_checks():

--- a/src/rook/processes/wps_health.py
+++ b/src/rook/processes/wps_health.py
@@ -2,10 +2,26 @@
 
 from pywps import LiteralOutput, Process
 from pywps.app.Common import Metadata
+from pywps.app.exceptions import ProcessError
+
+HEALTHY_RESPONSE = "ROOK_HEALTH_OK"
+
+
+class HealthCheckError(RuntimeError):
+    """Raised when an operational health check fails."""
+
+
+def run_health_checks():
+    """Run operational health checks or raise ``HealthCheckError``."""
 
 
 class Health(Process):
-    """Report that Rook can execute a WPS process."""
+    """Run the lightweight synchronous Rook health check.
+
+    Request the ``status`` output as ``RawDataOutput``. A healthy response is
+    exactly ``ROOK_HEALTH_OK``. Checks should raise ``HealthCheckError`` with a
+    concise explanation when unhealthy; the success marker is then omitted.
+    """
 
     def __init__(self):
         outputs = [
@@ -31,5 +47,10 @@ class Health(Process):
         )
 
     def _handler(self, _request, response):
-        response.outputs["status"].data = "ok"
+        try:
+            run_health_checks()
+        except HealthCheckError as exc:
+            raise ProcessError(f"Health check failed: {exc}") from exc
+
+        response.outputs["status"].data = HEALTHY_RESPONSE
         return response

--- a/src/rook/processes/wps_health.py
+++ b/src/rook/processes/wps_health.py
@@ -1,0 +1,35 @@
+"""Health-check process."""
+
+from pywps import LiteralOutput, Process
+from pywps.app.Common import Metadata
+
+
+class Health(Process):
+    """Report that Rook can execute a WPS process."""
+
+    def __init__(self):
+        outputs = [
+            LiteralOutput(
+                "status",
+                "Status",
+                abstract="Rook health status.",
+                data_type="string",
+            )
+        ]
+
+        super().__init__(
+            self._handler,
+            identifier="health",
+            title="Health",
+            abstract="Check whether Rook can execute a WPS process.",
+            metadata=[Metadata("ROOK", "https://github.com/roocs/rook")],
+            version="1.0",
+            inputs=[],
+            outputs=outputs,
+            store_supported=False,
+            status_supported=False,
+        )
+
+    def _handler(self, _request, response):
+        response.outputs["status"].data = "ok"
+        return response

--- a/src/rook/processes/wps_health.py
+++ b/src/rook/processes/wps_health.py
@@ -1,8 +1,12 @@
 """Health-check process."""
 
+from pathlib import Path
+
 from pywps import LiteralOutput, Process
 from pywps.app.Common import Metadata
 from pywps.app.exceptions import ProcessError
+
+from rook.config import ConfigurationError, get_health_readable_files
 
 HEALTHY_RESPONSE = "ROOK_HEALTH_OK"
 
@@ -13,6 +17,25 @@ class HealthCheckError(RuntimeError):
 
 def run_health_checks():
     """Run operational health checks or raise ``HealthCheckError``."""
+    try:
+        readable_files = get_health_readable_files()
+    except ConfigurationError as exc:
+        raise HealthCheckError(str(exc)) from exc
+
+    failures = []
+    for name, path in readable_files.items():
+        try:
+            with Path(path).open("rb") as stream:
+                stream.read(1)
+        except OSError as exc:
+            reason = exc.strerror or exc.__class__.__name__
+            failures.append(f"{name}: {reason}")
+        except ValueError:
+            failures.append(f"{name}: invalid path")
+
+    if failures:
+        detail = "; ".join(failures)
+        raise HealthCheckError(f"configured files are not readable: {detail}")
 
 
 class Health(Process):
@@ -21,6 +44,8 @@ class Health(Process):
     Request the ``status`` output as ``RawDataOutput``. A healthy response is
     exactly ``ROOK_HEALTH_OK``. Checks should raise ``HealthCheckError`` with a
     concise explanation when unhealthy; the success marker is then omitted.
+    The ``.health-check.txt`` file below every project selected in
+    ``health.projects`` is opened and read to verify filesystem access.
     """
 
     def __init__(self):

--- a/tests/smoke/test_smoke_checks.py
+++ b/tests/smoke/test_smoke_checks.py
@@ -1,7 +1,7 @@
 import json
 
 import pytest
-from owslib.wps import ComplexDataInput, monitorExecution
+from owslib.wps import ComplexDataInput
 
 pytestmark = [pytest.mark.smoke, pytest.mark.online]
 
@@ -298,8 +298,7 @@ def test_smoke_get_capabilities(wps):
 
 
 def test_smoke_execute_health(wps):
-    execution = wps.wps.execute("health", [])
-    monitorExecution(execution)
+    execution = wps.wps.execute("health", [], mode="sync")
 
     assert execution.isSucceded() is True, execution.errors
     assert execution.processOutputs[0].data == "ok"

--- a/tests/smoke/test_smoke_checks.py
+++ b/tests/smoke/test_smoke_checks.py
@@ -1,7 +1,10 @@
 import json
 
 import pytest
+import requests
 from owslib.wps import ComplexDataInput
+
+from rook.processes.wps_health import HEALTHY_RESPONSE
 
 pytestmark = [pytest.mark.smoke, pytest.mark.online]
 
@@ -298,10 +301,20 @@ def test_smoke_get_capabilities(wps):
 
 
 def test_smoke_execute_health(wps):
-    execution = wps.wps.execute("health", [], mode="sync")
+    response = requests.get(
+        wps.wps.url,
+        params={
+            "service": "WPS",
+            "version": "1.0.0",
+            "request": "Execute",
+            "identifier": "health",
+            "RawDataOutput": "status",
+        },
+        timeout=30,
+    )
 
-    assert execution.isSucceded() is True, execution.errors
-    assert execution.processOutputs[0].data == "ok"
+    response.raise_for_status()
+    assert response.text == HEALTHY_RESPONSE
 
 
 def test_smoke_describe_process_subset(wps):

--- a/tests/smoke/test_smoke_checks.py
+++ b/tests/smoke/test_smoke_checks.py
@@ -1,7 +1,7 @@
 import json
 
 import pytest
-from owslib.wps import ComplexDataInput
+from owslib.wps import ComplexDataInput, monitorExecution
 
 pytestmark = [pytest.mark.smoke, pytest.mark.online]
 
@@ -293,7 +293,16 @@ def test_smoke_get_capabilities(wps):
     assert "subset" in processes
     assert "average" in processes
     assert "average_time" in processes
+    assert "health" in processes
     assert "orchestrate" in processes
+
+
+def test_smoke_execute_health(wps):
+    execution = wps.wps.execute("health", [])
+    monitorExecution(execution)
+
+    assert execution.isSucceded() is True, execution.errors
+    assert execution.processOutputs[0].data == "ok"
 
 
 def test_smoke_describe_process_subset(wps):

--- a/tests/storm/locustfile.py
+++ b/tests/storm/locustfile.py
@@ -18,7 +18,7 @@ class RookUser(HttpUser):
         query = "/health"
 
         with self.client.get(query, catch_response=True, name="health") as response:
-            if ">ok</wps:LiteralData>" not in response.text:
+            if response.text != "ROOK_HEALTH_OK":
                 response.failure("Health response not as expected")
 
     @tag("meta")

--- a/tests/storm/locustfile.py
+++ b/tests/storm/locustfile.py
@@ -18,7 +18,7 @@ class RookUser(HttpUser):
         query = "/health"
 
         with self.client.get(query, catch_response=True, name="health") as response:
-            if "<ows:Title>rook</ows:Title>" not in response.text:
+            if ">ok</wps:LiteralData>" not in response.text:
                 response.failure("Health response not as expected")
 
     @tag("meta")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -64,6 +64,55 @@ def test_get_fix_backend_rejects_unknown_backend(monkeypatch):
         config.get_fix_backend()
 
 
+def test_health_readable_files_default_to_empty(monkeypatch):
+    monkeypatch.setattr(config, "_CONFIG", {})
+
+    assert config.get_health_readable_files() == {}
+
+
+def test_health_readable_files_use_project_base_dirs(monkeypatch):
+    monkeypatch.setattr(
+        config,
+        "_CONFIG",
+        {
+            "health": {"projects": "c3s-cordex, c3s-cica-atlas"},
+            "project:c3s-cordex": {"base_dir": "/data/c3s-cordex"},
+            "project:c3s-cica-atlas": {"base_dir": "/data/c3s-cica-atlas"},
+        },
+    )
+
+    assert config.get_health_readable_files() == {
+        "c3s-cordex": "/data/c3s-cordex/.health-check.txt",
+        "c3s-cica-atlas": "/data/c3s-cica-atlas/.health-check.txt",
+    }
+
+
+@pytest.mark.parametrize(
+    "value",
+    [123, "c3s-cordex,", ",c3s-cordex"],
+)
+def test_health_readable_files_reject_invalid_config(monkeypatch, value):
+    monkeypatch.setattr(
+        config,
+        "_CONFIG",
+        {"health": {"projects": value}},
+    )
+
+    with pytest.raises(config.ConfigurationError, match=r"health\.projects"):
+        config.get_health_readable_files()
+
+
+def test_health_readable_files_require_project_base_dir(monkeypatch):
+    monkeypatch.setattr(
+        config,
+        "_CONFIG",
+        {"health": {"projects": "c3s-cordex"}},
+    )
+
+    with pytest.raises(config.ConfigurationError, match=r"c3s-cordex.*base_dir"):
+        config.get_health_readable_files()
+
+
 def test_s3_options_reject_malformed_optional_json_without_exposing_value(monkeypatch):
     malformed_value = "not-json-private-value"
     monkeypatch.setattr(

--- a/tests/test_wps_caps.py
+++ b/tests/test_wps_caps.py
@@ -15,6 +15,7 @@ def test_wps_caps(client_for):
         "average_time",
         "concat",
         "dashboard",
+        "health",
         "orchestrate",
         "regrid",
         "subset",

--- a/tests/test_wps_health.py
+++ b/tests/test_wps_health.py
@@ -3,7 +3,8 @@ from pywps import Service
 from pywps.tests import client_for
 
 import rook.processes.wps_health as health_module
-from rook.processes.wps_health import HEALTHY_RESPONSE, Health, HealthCheckError
+from rook.exceptions import HealthCheckError
+from rook.processes.wps_health import HEALTHY_RESPONSE, Health
 
 
 def execute_health(client):

--- a/tests/test_wps_health.py
+++ b/tests/test_wps_health.py
@@ -1,0 +1,15 @@
+from pywps import Service
+from pywps.tests import assert_response_success, client_for
+
+from rook.processes.wps_health import Health
+
+
+def test_wps_health(get_output):
+    client = client_for(Service(processes=[Health()]))
+
+    response = client.get(
+        "?service=WPS&request=Execute&version=1.0.0&identifier=health"
+    )
+
+    assert_response_success(response)
+    assert get_output(response.xml)["status"] == "ok"

--- a/tests/test_wps_health.py
+++ b/tests/test_wps_health.py
@@ -1,3 +1,4 @@
+import pytest
 from pywps import Service
 from pywps.tests import client_for
 
@@ -34,3 +35,40 @@ def test_wps_health_explains_failed_check(monkeypatch):
     assert response.status_code == 400
     assert HEALTHY_RESPONSE.encode() not in response.data
     assert b"Health check failed: catalog database is unavailable" in response.data
+
+
+def test_health_checks_read_each_configured_file(monkeypatch, tmp_path):
+    cmip6 = tmp_path / "cmip6" / ".health-check.txt"
+    atlas = tmp_path / "atlas" / ".health-check.txt"
+    cmip6.parent.mkdir()
+    atlas.parent.mkdir()
+    cmip6.write_bytes(b"healthy")
+    atlas.write_bytes(b"healthy")
+    monkeypatch.setattr(
+        health_module,
+        "get_health_readable_files",
+        lambda: {"cmip6": str(cmip6), "atlas": str(atlas)},
+    )
+
+    health_module.run_health_checks()
+
+
+def test_health_checks_report_names_without_exposing_paths(monkeypatch, tmp_path):
+    missing_cmip6 = tmp_path / "private" / "cmip6.nc"
+    missing_atlas = tmp_path / "private" / "atlas.nc"
+    monkeypatch.setattr(
+        health_module,
+        "get_health_readable_files",
+        lambda: {
+            "cmip6": str(missing_cmip6),
+            "atlas": str(missing_atlas),
+        },
+    )
+
+    with pytest.raises(HealthCheckError) as exc_info:
+        health_module.run_health_checks()
+
+    message = str(exc_info.value)
+    assert "cmip6: No such file or directory" in message
+    assert "atlas: No such file or directory" in message
+    assert str(tmp_path) not in message

--- a/tests/test_wps_health.py
+++ b/tests/test_wps_health.py
@@ -1,15 +1,36 @@
 from pywps import Service
-from pywps.tests import assert_response_success, client_for
+from pywps.tests import client_for
 
-from rook.processes.wps_health import Health
+import rook.processes.wps_health as health_module
+from rook.processes.wps_health import HEALTHY_RESPONSE, Health, HealthCheckError
 
 
-def test_wps_health(get_output):
-    client = client_for(Service(processes=[Health()]))
-
-    response = client.get(
+def execute_health(client):
+    return client.get(
         "?service=WPS&request=Execute&version=1.0.0&identifier=health"
+        "&RawDataOutput=status"
     )
 
-    assert_response_success(response)
-    assert get_output(response.xml)["status"] == "ok"
+
+def test_wps_health_returns_raw_success_marker():
+    client = client_for(Service(processes=[Health()]))
+
+    response = execute_health(client)
+
+    assert response.status_code == 200
+    assert response.content_type == "text/plain; charset=utf-8"
+    assert response.data.decode() == HEALTHY_RESPONSE
+
+
+def test_wps_health_explains_failed_check(monkeypatch):
+    def fail_check():
+        raise HealthCheckError("catalog database is unavailable")
+
+    monkeypatch.setattr(health_module, "run_health_checks", fail_check)
+    client = client_for(Service(processes=[Health()]))
+
+    response = execute_health(client)
+
+    assert response.status_code == 400
+    assert HEALTHY_RESPONSE.encode() not in response.data
+    assert b"Health check failed: catalog database is unavailable" in response.data


### PR DESCRIPTION
## Overview

This PR adds a simple health check process

Changes:

* Added a health check process ... sync mode only.
* The health process can can if configured data sources (from roocs.ini) are readable.
* The health process can be used in an nginx endpoint for LB checks (using the raw output).

## Related Issue / Discussion

## Additional Information


